### PR TITLE
Add unit tests for word actions, addWords reducer, and auth actions

### DIFF
--- a/web-client/src/setupTests.ts
+++ b/web-client/src/setupTests.ts
@@ -2,4 +2,26 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
+
+// Mock Web Speech API (not available in jsdom)
+Object.defineProperty(window, 'speechSynthesis', {
+  value: {
+    getVoices: () => [],
+    speak: () => {},
+    cancel: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  },
+  writable: true,
+});
+
+Object.defineProperty(window, 'SpeechRecognition', {
+  value: undefined,
+  writable: true,
+});
+
+Object.defineProperty(window, 'webkitSpeechRecognition', {
+  value: undefined,
+  writable: true,
+});

--- a/web-client/src/store/actions/auth.test.ts
+++ b/web-client/src/store/actions/auth.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestStore } from '../../test/utils';
+import * as authActions from './auth';
+import * as firebaseAuth from '../../firebase/auth';
+import { FirebaseError } from 'firebase/app';
+
+vi.mock('../../firebase/auth');
+
+const mockedAuth = vi.mocked(firebaseAuth);
+
+function makeUser(uid: string) {
+  return { uid } as firebaseAuth.User;
+}
+
+const defaultStoreState = {
+  auth: {
+    userId: null,
+    loading: false,
+    error: null,
+    newSignUp: false,
+    initialized: false,
+    modalOpen: false,
+    modalMode: 'login' as const,
+  },
+  addWords: { words: [], error: false, loading: false },
+  settings: { speechAvailable: false, synthAvailable: false },
+};
+
+describe('auth action thunks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('auth (login)', () => {
+    it('dispatches AUTH_START then AUTH_SUCCESS on successful login', async () => {
+      mockedAuth.loginUser.mockResolvedValue(makeUser('user-abc'));
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.auth('test@example.com', 'password123') as any);
+
+      const state = store.getState().auth;
+      expect(state.userId).toBe('user-abc');
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.initialized).toBe(true);
+    });
+
+    it('dispatches AUTH_FAIL with friendly message on invalid-credential', async () => {
+      const firebaseError = new FirebaseError(
+        'auth/invalid-credential',
+        'Firebase: Error (auth/invalid-credential).'
+      );
+      mockedAuth.loginUser.mockRejectedValue(firebaseError);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.auth('test@example.com', 'wrong') as any);
+
+      const state = store.getState().auth;
+      expect(state.userId).toBeNull();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe('Invalid email or password');
+    });
+
+    it('dispatches AUTH_FAIL with generic message on non-Firebase error', async () => {
+      mockedAuth.loginUser.mockRejectedValue(new Error('Network failed'));
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.auth('test@example.com', 'pw') as any);
+
+      expect(store.getState().auth.error).toBe('Login failed');
+    });
+  });
+
+  describe('register', () => {
+    it('dispatches AUTH_SUCCESS on successful registration', async () => {
+      mockedAuth.registerUser.mockResolvedValue(makeUser('new-user-1'));
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.register('new@example.com', 'secure123') as any);
+
+      const state = store.getState().auth;
+      expect(state.userId).toBe('new-user-1');
+      expect(state.loading).toBe(false);
+    });
+
+    it('dispatches AUTH_FAIL for weak-password', async () => {
+      const firebaseError = new FirebaseError(
+        'auth/weak-password',
+        'Firebase: Password should be at least 6 characters (auth/weak-password).'
+      );
+      mockedAuth.registerUser.mockRejectedValue(firebaseError);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.register('new@example.com', '123') as any);
+
+      expect(store.getState().auth.error).toBe('Password is too weak');
+    });
+
+    it('dispatches AUTH_FAIL for email-already-in-use', async () => {
+      const firebaseError = new FirebaseError(
+        'auth/email-already-in-use',
+        'Firebase: Error (auth/email-already-in-use).'
+      );
+      mockedAuth.registerUser.mockRejectedValue(firebaseError);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.register('taken@example.com', 'pw123456') as any);
+
+      expect(store.getState().auth.error).toBe('This email is already registered');
+    });
+  });
+
+  describe('logout', () => {
+    it('calls logoutUser and dispatches AUTH_LOGOUT', async () => {
+      mockedAuth.logoutUser.mockResolvedValue(undefined);
+      const store = createTestStore({
+        ...defaultStoreState,
+        auth: {
+          ...defaultStoreState.auth,
+          userId: 'user-abc',
+          initialized: true,
+        },
+      });
+
+      await store.dispatch(authActions.logout() as any);
+
+      expect(mockedAuth.logoutUser).toHaveBeenCalled();
+      expect(store.getState().auth.userId).toBeNull();
+    });
+
+    it('dispatches AUTH_LOGOUT even if logoutUser throws', async () => {
+      mockedAuth.logoutUser.mockRejectedValue(new Error('Firebase offline'));
+      const store = createTestStore({
+        ...defaultStoreState,
+        auth: {
+          ...defaultStoreState.auth,
+          userId: 'user-abc',
+          initialized: true,
+        },
+      });
+
+      await store.dispatch(authActions.logout() as any);
+
+      expect(store.getState().auth.userId).toBeNull();
+    });
+  });
+
+  describe('googleSignIn', () => {
+    it('dispatches AUTH_SUCCESS on successful Google sign-in', async () => {
+      mockedAuth.signInWithGoogle.mockResolvedValue(makeUser('google-user-1'));
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.googleSignIn() as any);
+
+      expect(store.getState().auth.userId).toBe('google-user-1');
+    });
+
+    it('suppresses error for popup-closed-by-user', async () => {
+      const firebaseError = new FirebaseError(
+        'auth/popup-closed-by-user',
+        'Firebase: Error (auth/popup-closed-by-user).'
+      );
+      mockedAuth.signInWithGoogle.mockRejectedValue(firebaseError);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.googleSignIn() as any);
+
+      // Empty string error means silently handled
+      expect(store.getState().auth.error).toBe('');
+    });
+  });
+
+  describe('initAuthListener', () => {
+    it('dispatches AUTH_SUCCESS when user is authenticated', () => {
+      let authCallback: ((user: firebaseAuth.User | null) => void) | null = null;
+      mockedAuth.subscribeToAuthChanges.mockImplementation((cb) => {
+        authCallback = cb;
+        return vi.fn();
+      });
+      const store = createTestStore(defaultStoreState);
+
+      store.dispatch(authActions.initAuthListener() as any);
+
+      expect(mockedAuth.subscribeToAuthChanges).toHaveBeenCalled();
+
+      // Simulate Firebase calling back with a user
+      authCallback!(makeUser('restored-user'));
+      expect(store.getState().auth.userId).toBe('restored-user');
+      expect(store.getState().auth.initialized).toBe(true);
+    });
+
+    it('dispatches AUTH_INITIALIZED when no user', () => {
+      let authCallback: ((user: firebaseAuth.User | null) => void) | null = null;
+      mockedAuth.subscribeToAuthChanges.mockImplementation((cb) => {
+        authCallback = cb;
+        return vi.fn();
+      });
+      const store = createTestStore(defaultStoreState);
+
+      store.dispatch(authActions.initAuthListener() as any);
+
+      authCallback!(null);
+      expect(store.getState().auth.userId).toBeNull();
+      expect(store.getState().auth.initialized).toBe(true);
+    });
+  });
+
+  describe('action creators', () => {
+    it('openAuthModal creates correct action', () => {
+      expect(authActions.openAuthModal('register')).toEqual({
+        type: 'OPEN_AUTH_MODAL',
+        mode: 'register',
+      });
+    });
+
+    it('closeAuthModal creates correct action', () => {
+      expect(authActions.closeAuthModal()).toEqual({
+        type: 'CLOSE_AUTH_MODAL',
+      });
+    });
+
+    it('setAuthModalMode creates correct action', () => {
+      expect(authActions.setAuthModalMode('login')).toEqual({
+        type: 'SET_AUTH_MODAL_MODE',
+        mode: 'login',
+      });
+    });
+  });
+});

--- a/web-client/src/store/actions/word.test.ts
+++ b/web-client/src/store/actions/word.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestStore, authenticatedState } from '../../test/utils';
+import * as wordActions from './word';
+import * as wordService from '../../services/wordService';
+import * as streakService from '../../services/streakService';
+import { Word } from '../../types/models';
+
+vi.mock('../../services/wordService');
+vi.mock('../../services/streakService');
+
+const mockedWordService = vi.mocked(wordService);
+const mockedStreakService = vi.mocked(streakService);
+
+const sampleWord: Word = {
+  id: 1,
+  simp: '你好',
+  trad: '你好',
+  pinyin: 'nǐ hǎo',
+  meaning: 'hello',
+};
+
+const sampleWords: Word[] = [
+  sampleWord,
+  {
+    id: 2,
+    simp: '谢谢',
+    trad: '謝謝',
+    pinyin: 'xiè xie',
+    meaning: 'thank you',
+    bank: 2,
+    due_date: '2026/03/01',
+  },
+];
+
+describe('word action thunks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initWords', () => {
+    it('fetches words and dispatches SET_WORDS on success', async () => {
+      mockedWordService.getUserWords.mockResolvedValue(sampleWords);
+      const store = createTestStore(authenticatedState());
+
+      await store.dispatch(wordActions.initWords() as any);
+
+      expect(mockedWordService.getUserWords).toHaveBeenCalledWith('test-user-123');
+      expect(store.getState().addWords.words).toEqual(sampleWords);
+      expect(store.getState().addWords.error).toBe(false);
+    });
+
+    it('dispatches FETCH_WORDS_FAILED when no userId', async () => {
+      const store = createTestStore({
+        auth: {
+          userId: null,
+          loading: false,
+          error: null,
+          newSignUp: false,
+          initialized: true,
+          modalOpen: false,
+          modalMode: 'login',
+        },
+        addWords: { words: [], error: false, loading: false },
+        settings: { speechAvailable: false, synthAvailable: false },
+      });
+
+      await store.dispatch(wordActions.initWords() as any);
+
+      expect(mockedWordService.getUserWords).not.toHaveBeenCalled();
+      expect(store.getState().addWords.error).toBe(true);
+    });
+
+    it('dispatches FETCH_WORDS_FAILED on service error', async () => {
+      mockedWordService.getUserWords.mockRejectedValue(new Error('Network error'));
+      const store = createTestStore(authenticatedState());
+
+      await store.dispatch(wordActions.initWords() as any);
+
+      expect(store.getState().addWords.error).toBe(true);
+    });
+  });
+
+  describe('postWord', () => {
+    it('calls addWordToBank and dispatches ADD_WORD', async () => {
+      mockedWordService.addWordToBank.mockResolvedValue(undefined);
+      const store = createTestStore(authenticatedState());
+
+      await store.dispatch(wordActions.postWord(sampleWord) as any);
+
+      expect(mockedWordService.addWordToBank).toHaveBeenCalledWith(
+        'test-user-123',
+        sampleWord
+      );
+      expect(store.getState().addWords.words).toHaveLength(1);
+      expect(store.getState().addWords.words[0].simp).toBe('你好');
+    });
+
+    it('does nothing when no userId', async () => {
+      const store = createTestStore({
+        auth: {
+          userId: null,
+          loading: false,
+          error: null,
+          newSignUp: false,
+          initialized: true,
+          modalOpen: false,
+          modalMode: 'login',
+        },
+        addWords: { words: [], error: false, loading: false },
+        settings: { speechAvailable: false, synthAvailable: false },
+      });
+
+      await store.dispatch(wordActions.postWord(sampleWord) as any);
+
+      expect(mockedWordService.addWordToBank).not.toHaveBeenCalled();
+      expect(store.getState().addWords.words).toHaveLength(0);
+    });
+  });
+
+  describe('deleteWord', () => {
+    it('calls removeWordFromBank and dispatches REMOVE_WORD', async () => {
+      mockedWordService.removeWordFromBank.mockResolvedValue(undefined);
+      const store = createTestStore({
+        ...authenticatedState(),
+        addWords: { words: [sampleWord], error: false, loading: false },
+      });
+
+      await store.dispatch(wordActions.deleteWord(1) as any);
+
+      expect(mockedWordService.removeWordFromBank).toHaveBeenCalledWith(
+        'test-user-123',
+        1
+      );
+      expect(store.getState().addWords.words).toHaveLength(0);
+    });
+  });
+
+  describe('postUpdateMeaning', () => {
+    it('calls updateWordMeaning and dispatches UPDATE_MEANING', async () => {
+      mockedWordService.updateWordMeaning.mockResolvedValue(undefined);
+      const store = createTestStore({
+        ...authenticatedState(),
+        addWords: { words: [sampleWord], error: false, loading: false },
+      });
+
+      await store.dispatch(wordActions.postUpdateMeaning(1, 'hi there') as any);
+
+      expect(mockedWordService.updateWordMeaning).toHaveBeenCalledWith(
+        'test-user-123',
+        1,
+        'hi there'
+      );
+      expect(store.getState().addWords.words[0].meaning).toBe('hi there');
+    });
+  });
+
+  describe('finishTest', () => {
+    const scores = [
+      { word_id: 1, score: 4 },
+      { word_id: 2, score: 2 },
+    ];
+
+    it('calls wordService.finishTest and recordTestCompletion', async () => {
+      mockedWordService.finishTest.mockResolvedValue({ '你好': '2026/03/05' });
+      mockedStreakService.recordTestCompletion.mockResolvedValue(undefined);
+      const store = createTestStore(authenticatedState());
+
+      await store.dispatch(wordActions.finishTest(scores) as any);
+
+      expect(mockedWordService.finishTest).toHaveBeenCalledWith(
+        'test-user-123',
+        scores
+      );
+      expect(mockedStreakService.recordTestCompletion).toHaveBeenCalledWith(
+        'test-user-123'
+      );
+    });
+
+    it('still succeeds if streak recording fails', async () => {
+      mockedWordService.finishTest.mockResolvedValue({ '你好': '2026/03/05' });
+      mockedStreakService.recordTestCompletion.mockRejectedValue(
+        new Error('streak error')
+      );
+      const store = createTestStore(authenticatedState());
+
+      // Should not throw
+      await store.dispatch(wordActions.finishTest(scores) as any);
+
+      expect(mockedWordService.finishTest).toHaveBeenCalled();
+      expect(mockedStreakService.recordTestCompletion).toHaveBeenCalled();
+    });
+
+    it('does nothing when no userId', async () => {
+      const store = createTestStore({
+        auth: {
+          userId: null,
+          loading: false,
+          error: null,
+          newSignUp: false,
+          initialized: true,
+          modalOpen: false,
+          modalMode: 'login',
+        },
+        addWords: { words: [], error: false, loading: false },
+        settings: { speechAvailable: false, synthAvailable: false },
+      });
+
+      await store.dispatch(wordActions.finishTest(scores) as any);
+
+      expect(mockedWordService.finishTest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('postCustomWord', () => {
+    it('calls addCustomWord and dispatches ADD_CUSTOM_WORD', async () => {
+      const customWord: Word = {
+        id: -1000,
+        simp: '学习',
+        trad: '學習',
+        pinyin: 'xué xí',
+        meaning: 'to study',
+      };
+      mockedWordService.addCustomWord.mockResolvedValue(customWord);
+      const store = createTestStore(authenticatedState());
+
+      await store.dispatch(
+        wordActions.postCustomWord({
+          text: '学习',
+          meaning: 'to study',
+          charSet: 'simp',
+        }) as any
+      );
+
+      expect(mockedWordService.addCustomWord).toHaveBeenCalledWith(
+        'test-user-123',
+        '学习',
+        'to study',
+        'simp'
+      );
+      expect(store.getState().addWords.words).toHaveLength(1);
+      expect(store.getState().addWords.words[0].simp).toBe('学习');
+    });
+  });
+});

--- a/web-client/src/store/reducers/addWords.test.ts
+++ b/web-client/src/store/reducers/addWords.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import reducer from './addWords';
+import * as actionTypes from '../actions/actionTypes';
+import { AddWordsState } from '../../types/store';
+import { Word } from '../../types/models';
+
+const initialState: AddWordsState = {
+  words: [],
+  error: false,
+  loading: false,
+};
+
+const sampleWord: Word = {
+  id: 1,
+  simp: '你好',
+  trad: '你好',
+  pinyin: 'nǐ hǎo',
+  meaning: 'hello',
+};
+
+function formatToday(date: Date): string {
+  const day = date.getDate() >= 10
+    ? date.getDate().toString()
+    : '0' + date.getDate().toString();
+  const month = date.getMonth() >= 9
+    ? (date.getMonth() + 1).toString()
+    : '0' + (date.getMonth() + 1).toString();
+  return date.getFullYear() + '/' + month + '/' + day;
+}
+
+describe('addWords reducer', () => {
+  it('returns initial state for unknown action', () => {
+    const state = reducer(undefined, { type: 'UNKNOWN' } as any);
+    expect(state).toEqual(initialState);
+  });
+
+  describe('ADD_WORD', () => {
+    it('adds a word with due_date set to today and bank 1', () => {
+      const state = reducer(initialState, {
+        type: actionTypes.ADD_WORD,
+        word: sampleWord,
+      });
+
+      expect(state.words).toHaveLength(1);
+      expect(state.words[0].simp).toBe('你好');
+      expect(state.words[0].bank).toBe(1);
+      expect(state.words[0].due_date).toBe(formatToday(new Date()));
+    });
+
+    it('sets due_date to tomorrow when more than 9 words exist', () => {
+      const wordsArray: Word[] = Array.from({ length: 10 }, (_, i) => ({
+        id: i,
+        simp: `字${i}`,
+        trad: `字${i}`,
+        pinyin: `zì${i}`,
+        meaning: `char${i}`,
+      }));
+
+      const stateWith10 = { ...initialState, words: wordsArray };
+      const state = reducer(stateWith10, {
+        type: actionTypes.ADD_WORD,
+        word: sampleWord,
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      expect(state.words[0].due_date).toBe(formatToday(tomorrow));
+    });
+
+    it('prepends the new word to the beginning of the list', () => {
+      const existingWord: Word = {
+        id: 2,
+        simp: '谢谢',
+        trad: '謝謝',
+        pinyin: 'xiè xie',
+        meaning: 'thank you',
+      };
+
+      const stateWithWord = { ...initialState, words: [existingWord] };
+      const state = reducer(stateWithWord, {
+        type: actionTypes.ADD_WORD,
+        word: sampleWord,
+      });
+
+      expect(state.words).toHaveLength(2);
+      expect(state.words[0].simp).toBe('你好');
+      expect(state.words[1].simp).toBe('谢谢');
+    });
+  });
+
+  describe('ADD_CUSTOM_WORD', () => {
+    it('adds a custom word with due_date today and bank 1', () => {
+      const state = reducer(initialState, {
+        type: actionTypes.ADD_CUSTOM_WORD,
+        word: sampleWord,
+      });
+
+      expect(state.words).toHaveLength(1);
+      expect(state.words[0].bank).toBe(1);
+      expect(state.words[0].due_date).toBe(formatToday(new Date()));
+    });
+  });
+
+  describe('REMOVE_WORD', () => {
+    it('removes the word with the matching id', () => {
+      const stateWithWords = {
+        ...initialState,
+        words: [
+          sampleWord,
+          { id: 2, simp: '谢谢', trad: '謝謝', pinyin: 'xiè xie', meaning: 'thank you' },
+        ],
+      };
+
+      const state = reducer(stateWithWords, {
+        type: actionTypes.REMOVE_WORD,
+        wordID: 1,
+      });
+
+      expect(state.words).toHaveLength(1);
+      expect(state.words[0].id).toBe(2);
+    });
+
+    it('returns same state when removing non-existent id', () => {
+      const stateWithWord = { ...initialState, words: [sampleWord] };
+      const state = reducer(stateWithWord, {
+        type: actionTypes.REMOVE_WORD,
+        wordID: 999,
+      });
+
+      expect(state.words).toHaveLength(1);
+    });
+  });
+
+  describe('UPDATE_MEANING', () => {
+    it('updates the meaning of a matching word', () => {
+      const stateWithWord = { ...initialState, words: [sampleWord] };
+      const state = reducer(stateWithWord, {
+        type: actionTypes.UPDATE_MEANING,
+        wordID: 1,
+        newMeaning: 'hi there',
+      });
+
+      expect(state.words[0].meaning).toBe('hi there');
+    });
+
+    it('does not modify other words', () => {
+      const word2: Word = {
+        id: 2,
+        simp: '谢谢',
+        trad: '謝謝',
+        pinyin: 'xiè xie',
+        meaning: 'thank you',
+      };
+      const stateWithWords = { ...initialState, words: [sampleWord, word2] };
+      const state = reducer(stateWithWords, {
+        type: actionTypes.UPDATE_MEANING,
+        wordID: 1,
+        newMeaning: 'hi',
+      });
+
+      expect(state.words[0].meaning).toBe('hi');
+      expect(state.words[1].meaning).toBe('thank you');
+    });
+  });
+
+  describe('CLEAR_WORDS', () => {
+    it('clears all words', () => {
+      const stateWithWords = { ...initialState, words: [sampleWord] };
+      const state = reducer(stateWithWords, {
+        type: actionTypes.CLEAR_WORDS,
+      } as any);
+
+      expect(state.words).toEqual([]);
+    });
+  });
+
+  describe('SET_WORDS', () => {
+    it('sets words and clears error/loading', () => {
+      const loadingState = { ...initialState, loading: true, error: true };
+      const words = [sampleWord];
+      const state = reducer(loadingState, {
+        type: actionTypes.SET_WORDS,
+        words,
+      });
+
+      expect(state.words).toEqual(words);
+      expect(state.error).toBe(false);
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  describe('FETCH_WORDS', () => {
+    it('sets loading to true', () => {
+      const state = reducer(initialState, {
+        type: actionTypes.FETCH_WORDS,
+      } as any);
+
+      expect(state.loading).toBe(true);
+    });
+  });
+
+  describe('FETCH_WORDS_FAILED', () => {
+    it('sets error true and loading false', () => {
+      const loadingState = { ...initialState, loading: true };
+      const state = reducer(loadingState, {
+        type: actionTypes.FETCH_WORDS_FAILED,
+      });
+
+      expect(state.error).toBe(true);
+      expect(state.loading).toBe(false);
+    });
+  });
+});

--- a/web-client/src/test/utils.tsx
+++ b/web-client/src/test/utils.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import thunk from 'redux-thunk';
+
+import wordsReducer from '../store/reducers/addWords';
+import authReducer from '../store/reducers/auth';
+import settingsReducer from '../store/reducers/settings';
+
+export function createTestStore(preloadedState?: Record<string, unknown>) {
+  const rootReducer = combineReducers({
+    addWords: wordsReducer,
+    auth: authReducer,
+    settings: settingsReducer,
+  });
+  return createStore(rootReducer, preloadedState, applyMiddleware(thunk));
+}
+
+interface WrapperProps {
+  store?: ReturnType<typeof createTestStore>;
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    store = createTestStore(),
+    ...renderOptions
+  }: WrapperProps & RenderOptions = {}
+) {
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <Provider store={store}>
+        <BrowserRouter>{children}</BrowserRouter>
+      </Provider>
+    );
+  }
+  return { store, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
+}
+
+/** Authenticated store state — userId set, loading false, initialized true */
+export function authenticatedState(userId = 'test-user-123') {
+  return {
+    auth: {
+      userId,
+      loading: false,
+      error: null,
+      newSignUp: false,
+      initialized: true,
+      modalOpen: false,
+      modalMode: 'login' as const,
+    },
+    addWords: { words: [], error: false, loading: false },
+    settings: { speechAvailable: false, synthAvailable: false },
+  };
+}


### PR DESCRIPTION
Cover the three most critical untested code paths:
- Word action thunks: initWords, postWord, deleteWord, finishTest, postCustomWord
- addWords reducer: all action types including spaced repetition bank/due-date logic
- Auth action thunks: login, register, logout, Google sign-in, error mapping

Also fix setupTests.ts to mock Web Speech API (unblocking App.test.tsx) and fix authenticatedState() in test utils to use correct userId key.

40 tests, all passing.