### PR TITLE
Fix 6 bugs found during static analysis of codebase

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,16 +9,33 @@ service cloud.firestore {
 
     // Users can only access their own data
     match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId
+        && request.resource.data.keys().hasAll(['email', 'username', 'createdAt']);
 
       // UserWords subcollection
       match /userWords/{wordId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow create: if request.auth != null && request.auth.uid == userId
+          && request.resource.data.keys().hasAll(['wordData', 'bank', 'dueDate'])
+          && request.resource.data.bank is int
+          && request.resource.data.bank >= 1
+          && request.resource.data.bank <= 5;
+        allow update: if request.auth != null && request.auth.uid == userId
+          && (!('bank' in request.resource.data.diff(resource.data).affectedKeys())
+              || (request.resource.data.bank is int
+                  && request.resource.data.bank >= 1
+                  && request.resource.data.bank <= 5));
+        allow delete: if request.auth != null && request.auth.uid == userId;
       }
 
       // TestCompletions subcollection (streak tracking)
       match /testCompletions/{dateId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow write: if request.auth != null && request.auth.uid == userId
+          && request.resource.data.keys().hasAll(['completedAt', 'testsCount'])
+          && request.resource.data.testsCount is int
+          && request.resource.data.testsCount >= 1;
       }
     }
 

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -38,14 +38,18 @@ const App: React.FC<Props> = ({
   onSetLang,
 }) => {
   const setSpeech = useCallback((): Promise<SpeechSynthesisVoice[]> => {
-    return new Promise(function (resolve) {
+    return new Promise(function (resolve, reject) {
       const synth = window.speechSynthesis;
-      let id: NodeJS.Timeout;
+      let elapsed = 0;
 
-      id = setInterval(() => {
+      const id = setInterval(() => {
+        elapsed += 10;
         if (synth.getVoices().length !== 0) {
           resolve(synth.getVoices());
           clearInterval(id);
+        } else if (elapsed >= 5000) {
+          clearInterval(id);
+          reject(new Error('Speech synthesis voices not available'));
         }
       }, 10);
     });
@@ -76,6 +80,8 @@ const App: React.FC<Props> = ({
       } else {
         onSetSynthAvailable(false);
       }
+    }).catch(() => {
+      onSetSynthAvailable(false);
     });
   }, [onSetLang, onSetSynthAvailable, onSetVoice, setSpeech]);
 

--- a/web-client/src/services/dictionaryService.ts
+++ b/web-client/src/services/dictionaryService.ts
@@ -36,31 +36,37 @@ async function loadDictionary(): Promise<void> {
 
   loadingPromise = (async () => {
     console.log('Loading dictionary...');
-    const response = await fetch('/dictionary.json');
+    try {
+      const response = await fetch('/dictionary.json');
 
-    if (!response.ok) {
-      throw new Error(`Failed to load dictionary: ${response.status}`);
-    }
-
-    entries = await response.json();
-
-    // Build indexes for fast lookups
-    for (const entry of entries) {
-      // Index by simplified character
-      if (!simpIndex.has(entry.simp)) {
-        simpIndex.set(entry.simp, []);
+      if (!response.ok) {
+        throw new Error(`Failed to load dictionary: ${response.status}`);
       }
-      simpIndex.get(entry.simp)!.push(entry);
 
-      // Index by traditional character
-      if (!tradIndex.has(entry.trad)) {
-        tradIndex.set(entry.trad, []);
+      entries = await response.json();
+
+      // Build indexes for fast lookups
+      for (const entry of entries) {
+        // Index by simplified character
+        if (!simpIndex.has(entry.simp)) {
+          simpIndex.set(entry.simp, []);
+        }
+        simpIndex.get(entry.simp)!.push(entry);
+
+        // Index by traditional character
+        if (!tradIndex.has(entry.trad)) {
+          tradIndex.set(entry.trad, []);
+        }
+        tradIndex.get(entry.trad)!.push(entry);
       }
-      tradIndex.get(entry.trad)!.push(entry);
-    }
 
-    dictionaryLoaded = true;
-    console.log(`Dictionary loaded: ${entries.length} entries`);
+      dictionaryLoaded = true;
+      console.log(`Dictionary loaded: ${entries.length} entries`);
+    } catch (error) {
+      // Reset so subsequent calls can retry instead of returning the rejected promise forever
+      loadingPromise = null;
+      throw error;
+    }
   })();
 
   return loadingPromise;

--- a/web-client/src/services/streakService.test.ts
+++ b/web-client/src/services/streakService.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { calculateStreak } from './streakService';
+
+describe('calculateStreak', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 for empty dates array', () => {
+    expect(calculateStreak([])).toBe(0);
+  });
+
+  it('returns 1 when only today has a completion', () => {
+    vi.setSystemTime(new Date(2026, 1, 26, 10, 0, 0)); // Feb 26, 2026 10am local
+    expect(calculateStreak(['2026-02-26'])).toBe(1);
+  });
+
+  it('returns 1 when only yesterday has a completion', () => {
+    vi.setSystemTime(new Date(2026, 1, 26, 10, 0, 0));
+    expect(calculateStreak(['2026-02-25'])).toBe(1);
+  });
+
+  it('returns 0 when most recent completion is 2+ days ago', () => {
+    vi.setSystemTime(new Date(2026, 1, 26, 10, 0, 0));
+    expect(calculateStreak(['2026-02-24'])).toBe(0);
+  });
+
+  it('returns consecutive streak count', () => {
+    vi.setSystemTime(new Date(2026, 1, 26, 10, 0, 0));
+    // Dates sorted desc: today, yesterday, day before
+    expect(calculateStreak(['2026-02-26', '2026-02-25', '2026-02-24'])).toBe(3);
+  });
+
+  it('breaks streak on gap', () => {
+    vi.setSystemTime(new Date(2026, 1, 26, 10, 0, 0));
+    // Gap between Feb 25 and Feb 23
+    expect(calculateStreak(['2026-02-26', '2026-02-25', '2026-02-23'])).toBe(2);
+  });
+
+  it('handles same-day completion correctly (does not double-count)', () => {
+    vi.setSystemTime(new Date(2026, 1, 26, 10, 0, 0));
+    // Two entries for the same date should not break the streak
+    // but since docs are per-date, this shouldn't normally happen
+    // Still, duplicate dates should give diff=0 which breaks the streak at that point
+    expect(calculateStreak(['2026-02-26', '2026-02-26'])).toBe(1);
+  });
+
+  it('parses dates as local time, not UTC (timezone regression)', () => {
+    // Simulate a timezone where local midnight is ahead of UTC midnight
+    // e.g., UTC+8: local 2026-02-26 00:00 = UTC 2026-02-25 16:00
+    // If dates were parsed as UTC, "2026-02-26" would be UTC midnight,
+    // and local today would be Feb 26 local midnight (which is later).
+    // The fix uses parseLocalDate to avoid this discrepancy.
+    vi.setSystemTime(new Date(2026, 1, 26, 0, 30, 0)); // Just after local midnight
+    expect(calculateStreak(['2026-02-26'])).toBe(1);
+  });
+
+  it('handles month boundary correctly', () => {
+    vi.setSystemTime(new Date(2026, 2, 1, 10, 0, 0)); // March 1
+    expect(calculateStreak(['2026-03-01', '2026-02-28'])).toBe(2);
+  });
+});

--- a/web-client/src/services/streakService.ts
+++ b/web-client/src/services/streakService.ts
@@ -46,6 +46,16 @@ export const getStreakData = async (userId: string): Promise<{ date: string; tes
 };
 
 /**
+ * Parse a YYYY-MM-DD string as local midnight (not UTC).
+ * new Date("2026-02-26") parses as UTC midnight which causes timezone bugs
+ * in positive-offset timezones where local midnight is ahead of UTC midnight.
+ */
+function parseLocalDate(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/**
  * Calculate current streak from an array of completion date strings (already sorted desc).
  */
 export const calculateStreak = (dates: string[]): number => {
@@ -54,17 +64,14 @@ export const calculateStreak = (dates: string[]): number => {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const mostRecent = new Date(dates[0]);
-  mostRecent.setHours(0, 0, 0, 0);
+  const mostRecent = parseLocalDate(dates[0]);
   const diffFromToday = Math.floor((today.getTime() - mostRecent.getTime()) / (1000 * 60 * 60 * 24));
   if (diffFromToday > 1) return 0;
 
   let streak = 1;
   for (let i = 1; i < dates.length; i++) {
-    const prev = new Date(dates[i - 1]);
-    const curr = new Date(dates[i]);
-    prev.setHours(0, 0, 0, 0);
-    curr.setHours(0, 0, 0, 0);
+    const prev = parseLocalDate(dates[i - 1]);
+    const curr = parseLocalDate(dates[i]);
     const diff = Math.floor((prev.getTime() - curr.getTime()) / (1000 * 60 * 60 * 24));
     if (diff === 1) {
       streak++;

--- a/web-client/src/store/actions/word.test.ts
+++ b/web-client/src/store/actions/word.test.ts
@@ -160,8 +160,12 @@ describe('word action thunks', () => {
       { word_id: 2, score: 2 },
     ];
 
-    it('calls wordService.finishTest and recordTestCompletion', async () => {
+    it('calls wordService.finishTest, re-fetches words, and records streak', async () => {
+      const updatedWords = [
+        { ...sampleWord, bank: 2, due_date: '2026/03/05' },
+      ];
       mockedWordService.finishTest.mockResolvedValue({ '你好': '2026/03/05' });
+      mockedWordService.getUserWords.mockResolvedValue(updatedWords);
       mockedStreakService.recordTestCompletion.mockResolvedValue(undefined);
       const store = createTestStore(authenticatedState());
 
@@ -171,6 +175,11 @@ describe('word action thunks', () => {
         'test-user-123',
         scores
       );
+      expect(mockedWordService.getUserWords).toHaveBeenCalledWith(
+        'test-user-123'
+      );
+      // Verify the store was updated with refreshed words
+      expect(store.getState().addWords.words).toEqual(updatedWords);
       expect(mockedStreakService.recordTestCompletion).toHaveBeenCalledWith(
         'test-user-123'
       );
@@ -178,6 +187,7 @@ describe('word action thunks', () => {
 
     it('still succeeds if streak recording fails', async () => {
       mockedWordService.finishTest.mockResolvedValue({ '你好': '2026/03/05' });
+      mockedWordService.getUserWords.mockResolvedValue(sampleWords);
       mockedStreakService.recordTestCompletion.mockRejectedValue(
         new Error('streak error')
       );
@@ -187,6 +197,19 @@ describe('word action thunks', () => {
       await store.dispatch(wordActions.finishTest(scores) as any);
 
       expect(mockedWordService.finishTest).toHaveBeenCalled();
+      expect(mockedStreakService.recordTestCompletion).toHaveBeenCalled();
+    });
+
+    it('still records streak if word refresh fails', async () => {
+      mockedWordService.finishTest.mockResolvedValue({ '你好': '2026/03/05' });
+      mockedWordService.getUserWords.mockRejectedValue(new Error('fetch failed'));
+      mockedStreakService.recordTestCompletion.mockResolvedValue(undefined);
+      const store = createTestStore(authenticatedState());
+
+      await store.dispatch(wordActions.finishTest(scores) as any);
+
+      expect(mockedWordService.finishTest).toHaveBeenCalled();
+      expect(mockedWordService.getUserWords).toHaveBeenCalled();
       expect(mockedStreakService.recordTestCompletion).toHaveBeenCalled();
     });
 

--- a/web-client/src/store/actions/word.ts
+++ b/web-client/src/store/actions/word.ts
@@ -157,7 +157,8 @@ export const postUpdateMeaning = (
 };
 
 /**
- * Submit test results and update word banks in Firestore
+ * Submit test results and update word banks in Firestore.
+ * Re-fetches the full word list so Redux state reflects the new bank levels and due dates.
  */
 export const finishTest = (
   scores: { word_id: number; score: number }[]
@@ -167,8 +168,15 @@ export const finishTest = (
     if (!auth.userId) return;
 
     try {
-      const newDates = await wordService.finishTest(auth.userId, scores);
-      console.log('Test finished, new dates:', newDates);
+      await wordService.finishTest(auth.userId, scores);
+
+      // Re-fetch words so the local store has updated bank levels and due dates
+      try {
+        const updatedWords = await wordService.getUserWords(auth.userId);
+        dispatch(setWords(updatedWords));
+      } catch (fetchError) {
+        console.error('Failed to refresh words after test:', fetchError);
+      }
 
       try {
         await recordTestCompletion(auth.userId);

--- a/web-client/src/store/reducers/addWords.test.ts
+++ b/web-client/src/store/reducers/addWords.test.ts
@@ -99,6 +99,26 @@ describe('addWords reducer', () => {
       expect(state.words[0].bank).toBe(1);
       expect(state.words[0].due_date).toBe(formatToday(new Date()));
     });
+
+    it('sets due_date to tomorrow when more than 9 words exist (regression)', () => {
+      const wordsArray: Word[] = Array.from({ length: 10 }, (_, i) => ({
+        id: i,
+        simp: `字${i}`,
+        trad: `字${i}`,
+        pinyin: `zì${i}`,
+        meaning: `char${i}`,
+      }));
+
+      const stateWith10 = { ...initialState, words: wordsArray };
+      const state = reducer(stateWith10, {
+        type: actionTypes.ADD_CUSTOM_WORD,
+        word: sampleWord,
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      expect(state.words[0].due_date).toBe(formatToday(tomorrow));
+    });
   });
 
   describe('REMOVE_WORD', () => {

--- a/web-client/src/store/reducers/addWords.ts
+++ b/web-client/src/store/reducers/addWords.ts
@@ -38,6 +38,9 @@ const reducer = (state = initialState, action: WordAction): AddWordsState => {
     case actionTypes.ADD_CUSTOM_WORD: {
       const customWord = { ...action.word };
       const todayCustom = new Date();
+      if (state.words.length > 9) {
+        todayCustom.setDate(todayCustom.getDate() + 1);
+      }
 
       const todayDayCustom =
         todayCustom.getDate() >= 10


### PR DESCRIPTION
Bug 1 — finishTest action doesn't refresh Redux state after submitting scores: The finishTest thunk updated Firestore bank levels and due dates but never dispatched an action to update the local word store. Added a getUserWords re-fetch after finishTest completes so the UI reflects the new state.

Bug 2 — Firestore security rules allow arbitrary writes to user subcollections: userWords and testCompletions had no validation on write operations. Added field-level validation: userWords requires wordData/bank/dueDate with bank constrained to 1-5; testCompletions requires completedAt/testsCount >= 1.

Bug 3 — calculateStreak timezone bug due to UTC date parsing: Date strings like "2026-02-26" were parsed with new Date() which interprets them as UTC midnight. In positive UTC offset timezones, this caused the streak to show as 0 on the same day a test was completed. Added a parseLocalDate helper that constructs dates in local time.

Bug 4 — setSpeech interval in App.tsx polls forever if voices never load: The speechSynthesis.getVoices() polling loop had no timeout, causing a memory leak in environments where voices are never available (e.g. headless/CI). Added a 5-second timeout that rejects the promise and disables synthesis.

Bug 5 — ADD_CUSTOM_WORD reducer ignores >9 word count for due date: ADD_WORD correctly sets due date to tomorrow when the bank has >9 words, but ADD_CUSTOM_WORD always set today regardless. Applied the same logic.

Bug 6 — Dictionary loadingPromise not reset on fetch failure: If dictionary.json failed to load, loadingPromise held the rejected promise forever, making all subsequent dictionary lookups fail permanently until page reload. Reset loadingPromise to null on error so retries work.

All 51 tests pass (11 new regression tests added).