### PR TITLE
Add tests for TestLogic, wordService.finishTest, and dashboardService

### DIFF
--- a/web-client/src/components/Test/Logic/TestLogic.test.ts
+++ b/web-client/src/components/Test/Logic/TestLogic.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  chooseTestSet,
+  chooseRandomTestSet,
+  setPermList,
+  assignQA,
+  toneChecker,
+  Counter,
+  removePunctuation,
+} from './TestLogic';
+import { Word } from '../../../types/models';
+
+function makeWord(id: number, simp: string, due_date?: string): Word {
+  return {
+    id,
+    simp,
+    trad: simp,
+    pinyin: 'pīn yīn',
+    meaning: 'test meaning/other meaning',
+    due_date,
+    bank: 1,
+  };
+}
+
+describe('chooseTestSet', () => {
+  beforeEach(() => {
+    // Fix "today" to 2026-02-27
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 27, 10, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('includes words due today', () => {
+    const words = [makeWord(1, '你', '2026/02/27')];
+    const result = chooseTestSet(words, 10);
+    expect(result).toHaveLength(1);
+  });
+
+  it('includes words due in the past', () => {
+    const words = [makeWord(1, '你', '2026/02/20')];
+    const result = chooseTestSet(words, 10);
+    expect(result).toHaveLength(1);
+  });
+
+  it('excludes words due in the future', () => {
+    const words = [makeWord(1, '你', '2026/03/01')];
+    const result = chooseTestSet(words, 10);
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes words with no due_date', () => {
+    const words = [
+      makeWord(1, '你'),           // no due_date
+      makeWord(2, '好', '2026/02/20'), // past - due
+    ];
+    const result = chooseTestSet(words, 10);
+    expect(result).toHaveLength(1);
+    expect(result[0].simp).toBe('好');
+  });
+
+  it('caps result at numWords', () => {
+    const words = Array.from({ length: 10 }, (_, i) =>
+      makeWord(i, `字${i}`, '2026/02/20')
+    );
+    const result = chooseTestSet(words, 5);
+    expect(result).toHaveLength(5);
+  });
+
+  it('returns fewer than numWords when not enough due words', () => {
+    const words = [makeWord(1, '你', '2026/02/20')];
+    const result = chooseTestSet(words, 5);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns all words when numWords matches due words exactly', () => {
+    const words = [
+      makeWord(1, '你', '2026/02/20'),
+      makeWord(2, '好', '2026/02/21'),
+    ];
+    const result = chooseTestSet(words, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when no words are due', () => {
+    const words = [
+      makeWord(1, '你', '2026/03/01'),
+      makeWord(2, '好', '2026/03/02'),
+    ];
+    const result = chooseTestSet(words, 10);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns distinct words (no duplicates)', () => {
+    const words = Array.from({ length: 5 }, (_, i) =>
+      makeWord(i, `字${i}`, '2026/02/20')
+    );
+    const result = chooseTestSet(words, 5);
+    const ids = result.map((w) => w.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('chooseRandomTestSet', () => {
+  it('includes all words regardless of due_date', () => {
+    const words = [
+      makeWord(1, '你', '2099/01/01'), // far future
+      makeWord(2, '好'),               // no due_date
+      makeWord(3, '学', '2020/01/01'), // past
+    ];
+    const result = chooseRandomTestSet(words, 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it('caps at numWords', () => {
+    const words = Array.from({ length: 10 }, (_, i) => makeWord(i, `字${i}`));
+    const result = chooseRandomTestSet(words, 4);
+    expect(result).toHaveLength(4);
+  });
+
+  it('returns all words when numWords exceeds word bank size', () => {
+    const words = [makeWord(1, '你'), makeWord(2, '好')];
+    const result = chooseRandomTestSet(words, 20);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns distinct words (no duplicates)', () => {
+    const words = Array.from({ length: 5 }, (_, i) => makeWord(i, `字${i}`));
+    const result = chooseRandomTestSet(words, 5);
+    const ids = result.map((w) => w.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('setPermList', () => {
+  const twoWords = [makeWord(1, '你'), makeWord(2, '好')];
+
+  it('creates 4 Q/A combinations per word when handwriting excluded', () => {
+    const perms = setPermList(twoWords, false);
+    // 2 words × 4 combinations (PC, PM, MP, MC) = 8
+    expect(perms).toHaveLength(8);
+  });
+
+  it('creates 5 Q/A combinations per word when handwriting included', () => {
+    const perms = setPermList(twoWords, true);
+    // 2 words × 5 combinations (CM, PC, PM, MP, MC) = 10
+    expect(perms).toHaveLength(10);
+  });
+
+  it('each perm has index, aCategory, qCategory fields', () => {
+    const perms = setPermList([makeWord(0, '你')], false);
+    perms.forEach((p) => {
+      expect(p).toHaveProperty('index');
+      expect(p).toHaveProperty('aCategory');
+      expect(p).toHaveProperty('qCategory');
+    });
+  });
+
+  it('filters to only priority perms when onlyPriority=true', () => {
+    const perms = setPermList(twoWords, false, 'PC', true);
+    // aCategory='P', qCategory='C' — one perm per word
+    expect(perms).toHaveLength(2);
+    perms.forEach((p) => {
+      expect(p.aCategory).toBe('P');
+      expect(p.qCategory).toBe('C');
+    });
+  });
+
+  it('returns all perms when onlyPriority=false even with priority set', () => {
+    const perms = setPermList(twoWords, false, 'PC', false);
+    expect(perms).toHaveLength(8);
+  });
+
+  it('returns empty array for empty test set', () => {
+    const perms = setPermList([], false);
+    expect(perms).toHaveLength(0);
+  });
+});
+
+describe('assignQA', () => {
+  const word: Word = {
+    id: 1,
+    simp: '你好',
+    trad: '妳好',
+    pinyin: 'nǐ hǎo',
+    meaning: 'hello/hi',
+  };
+  const testSet = [word];
+
+  it('returns character (simp) as answer for aCategory=C, simp charSet', () => {
+    const perms = [{ index: '0', aCategory: 'C' as const, qCategory: 'M' as const }];
+    const result = assignQA(testSet, perms, 'simp');
+    expect(result.answer).toBe('你好');
+    expect(result.answerCategory).toBe('character');
+  });
+
+  it('returns character (trad) as answer for aCategory=C, trad charSet', () => {
+    const perms = [{ index: '0', aCategory: 'C' as const, qCategory: 'P' as const }];
+    const result = assignQA(testSet, perms, 'trad');
+    expect(result.answer).toBe('妳好');
+    expect(result.chosenCharacter).toBe('妳好');
+  });
+
+  it('returns pinyin as answer for aCategory=P', () => {
+    const perms = [{ index: '0', aCategory: 'P' as const, qCategory: 'C' as const }];
+    const result = assignQA(testSet, perms, 'simp');
+    expect(result.answer).toBe('nǐ hǎo');
+    expect(result.answerCategory).toBe('pinyin');
+  });
+
+  it('returns meaning array as answer for aCategory=M', () => {
+    const perms = [{ index: '0', aCategory: 'M' as const, qCategory: 'C' as const }];
+    const result = assignQA(testSet, perms, 'simp');
+    expect(result.answer).toEqual(['hello', 'hi']);
+    expect(result.answerCategory).toBe('meaning');
+  });
+
+  it('returns meaning array as question for qCategory=M', () => {
+    const perms = [{ index: '0', aCategory: 'C' as const, qCategory: 'M' as const }];
+    const result = assignQA(testSet, perms, 'simp');
+    expect(result.question).toEqual(['hello', 'hi']);
+    expect(result.questionCategory).toBe('meaning');
+  });
+
+  it('returns pinyin as question for qCategory=P', () => {
+    const perms = [{ index: '0', aCategory: 'C' as const, qCategory: 'P' as const }];
+    const result = assignQA(testSet, perms, 'simp');
+    expect(result.question).toBe('nǐ hǎo');
+    expect(result.questionCategory).toBe('pinyin');
+  });
+
+  it('returns character as question for qCategory=C', () => {
+    const perms = [{ index: '0', aCategory: 'M' as const, qCategory: 'C' as const }];
+    const result = assignQA(testSet, perms, 'simp');
+    expect(result.question).toBe('你好');
+    expect(result.questionCategory).toBe('character');
+  });
+
+  it('returns the perm that was selected', () => {
+    const perm = { index: '0', aCategory: 'C' as const, qCategory: 'M' as const };
+    const result = assignQA(testSet, [perm], 'simp');
+    expect(result.perm).toBe(perm);
+  });
+
+  it('prefers priority perms when priority is set and matches exist', () => {
+    const permList = [
+      { index: '0', aCategory: 'P' as const, qCategory: 'C' as const },
+      { index: '0', aCategory: 'C' as const, qCategory: 'M' as const },
+      { index: '0', aCategory: 'M' as const, qCategory: 'P' as const },
+    ];
+    // Run many times to confirm priority perm is always chosen
+    for (let i = 0; i < 20; i++) {
+      const result = assignQA(testSet, permList, 'simp', 'PC');
+      expect(result.answerCategory).toBe('pinyin');
+      expect(result.questionCategory).toBe('character');
+    }
+  });
+});
+
+describe('toneChecker', () => {
+  it('returns true when input exactly matches answer', () => {
+    expect(toneChecker('ni hao', 'ni hao')).toBe(true);
+  });
+
+  it('strips tone digits from both input and answer before comparing', () => {
+    expect(toneChecker('ni3 hao3', 'ni hao')).toBe(true);
+    expect(toneChecker('ni3hao3', 'nihao')).toBe(true);
+  });
+
+  it('strips digits from the answer side too', () => {
+    expect(toneChecker('ni hao', 'ni3 hao3')).toBe(true);
+  });
+
+  it('returns false when stripped strings differ', () => {
+    expect(toneChecker('hello', 'world')).toBe(false);
+    expect(toneChecker('ni3 hao3', 'ni ma')).toBe(false);
+  });
+
+  it('returns true for empty strings', () => {
+    expect(toneChecker('', '')).toBe(true);
+  });
+});
+
+describe('Counter', () => {
+  it('counts occurrences of each value', () => {
+    expect(Counter(['a', 'b', 'a', 'c', 'a', 'b'])).toEqual({
+      a: 3,
+      b: 2,
+      c: 1,
+    });
+  });
+
+  it('returns empty object for empty array', () => {
+    expect(Counter([])).toEqual({});
+  });
+
+  it('handles single-item array', () => {
+    expect(Counter(['x'])).toEqual({ x: 1 });
+  });
+
+  it('counts all distinct values', () => {
+    const result = Counter(['yes', 'no', 'yes', 'maybe', 'no', 'yes']);
+    expect(result.yes).toBe(3);
+    expect(result.no).toBe(2);
+    expect(result.maybe).toBe(1);
+  });
+});
+
+describe('removePunctuation', () => {
+  it('lowercases the input', () => {
+    expect(removePunctuation('Hello World')).toBe('hello world');
+  });
+
+  it('removes periods and commas', () => {
+    expect(removePunctuation('hello, world.')).toBe('hello world');
+  });
+
+  it('removes exclamation marks and hash', () => {
+    expect(removePunctuation('hello! #test')).toBe('hello test');
+  });
+
+  it('collapses multiple spaces into one', () => {
+    expect(removePunctuation('hello  world')).toBe('hello world');
+  });
+
+  it('handles a clean string without changes (beyond lowercasing)', () => {
+    expect(removePunctuation('hello world')).toBe('hello world');
+  });
+
+  it('removes slashes', () => {
+    expect(removePunctuation('hello/world')).toBe('helloworld');
+  });
+});

--- a/web-client/src/services/dashboardService.test.ts
+++ b/web-client/src/services/dashboardService.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getDashboardStats } from './dashboardService';
+import * as wordService from './wordService';
+import * as streakService from './streakService';
+import { Word } from '../types/models';
+
+vi.mock('./wordService');
+vi.mock('./streakService');
+
+const mockedWordService = vi.mocked(wordService);
+const mockedStreakService = vi.mocked(streakService);
+
+function makeWord(id: number, bank: number): Word {
+  return {
+    id,
+    simp: `字${id}`,
+    trad: `字${id}`,
+    pinyin: 'pīn',
+    meaning: 'meaning',
+    bank,
+    due_date: '2026/02/27',
+  };
+}
+
+describe('getDashboardStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // calculateStreak is a real function imported by dashboardService;
+    // mock it to return a fixed value for determinism
+    mockedStreakService.calculateStreak.mockReturnValue(3);
+    mockedStreakService.getStreakData.mockResolvedValue([
+      { date: '2026-02-25' },
+      { date: '2026-02-26' },
+      { date: '2026-02-27' },
+    ]);
+  });
+
+  it('returns correct totalWords count', async () => {
+    const allWords = [makeWord(1, 1), makeWord(2, 2), makeWord(3, 5)];
+    mockedWordService.getUserWords.mockResolvedValue(allWords);
+    mockedWordService.getDueUserWords.mockResolvedValue([allWords[0]]);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.totalWords).toBe(3);
+  });
+
+  it('returns correct dueWords count', async () => {
+    const allWords = [makeWord(1, 1), makeWord(2, 2), makeWord(3, 5)];
+    const due = [allWords[0], allWords[1]];
+    mockedWordService.getUserWords.mockResolvedValue(allWords);
+    mockedWordService.getDueUserWords.mockResolvedValue(due);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.dueWords).toBe(2);
+  });
+
+  it('computes bankDistribution correctly', async () => {
+    const allWords = [
+      makeWord(1, 1),
+      makeWord(2, 1),
+      makeWord(3, 3),
+      makeWord(4, 5),
+      makeWord(5, 5),
+    ];
+    mockedWordService.getUserWords.mockResolvedValue(allWords);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.bankDistribution[1]).toBe(2);
+    expect(stats.bankDistribution[2]).toBe(0);
+    expect(stats.bankDistribution[3]).toBe(1);
+    expect(stats.bankDistribution[4]).toBe(0);
+    expect(stats.bankDistribution[5]).toBe(2);
+  });
+
+  it('counts masteredCount from bank 5 words', async () => {
+    const allWords = [makeWord(1, 5), makeWord(2, 5), makeWord(3, 3)];
+    mockedWordService.getUserWords.mockResolvedValue(allWords);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.masteredCount).toBe(2);
+  });
+
+  it('treats missing bank as bank 1 in distribution', async () => {
+    const wordWithoutBank: Word = {
+      id: 99,
+      simp: '字',
+      trad: '字',
+      pinyin: 'zì',
+      meaning: 'character',
+      // bank is undefined
+    };
+    mockedWordService.getUserWords.mockResolvedValue([wordWithoutBank]);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.bankDistribution[1]).toBe(1);
+  });
+
+  it('returns streak from streakService', async () => {
+    mockedWordService.getUserWords.mockResolvedValue([]);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+    mockedStreakService.calculateStreak.mockReturnValue(5);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.streak).toBe(5);
+  });
+
+  it('masteredCount is 0 when no words are at bank 5', async () => {
+    const allWords = [makeWord(1, 1), makeWord(2, 2), makeWord(3, 3)];
+    mockedWordService.getUserWords.mockResolvedValue(allWords);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.masteredCount).toBe(0);
+  });
+
+  it('returns zero stats for empty word bank', async () => {
+    mockedWordService.getUserWords.mockResolvedValue([]);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+    mockedStreakService.calculateStreak.mockReturnValue(0);
+
+    const stats = await getDashboardStats('user-1');
+
+    expect(stats.totalWords).toBe(0);
+    expect(stats.dueWords).toBe(0);
+    expect(stats.masteredCount).toBe(0);
+    expect(stats.streak).toBe(0);
+    expect(stats.bankDistribution).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
+  });
+
+  it('calls all three services in parallel with the given userId', async () => {
+    mockedWordService.getUserWords.mockResolvedValue([]);
+    mockedWordService.getDueUserWords.mockResolvedValue([]);
+
+    await getDashboardStats('user-abc');
+
+    expect(mockedWordService.getUserWords).toHaveBeenCalledWith('user-abc');
+    expect(mockedWordService.getDueUserWords).toHaveBeenCalledWith('user-abc');
+    expect(mockedStreakService.getStreakData).toHaveBeenCalledWith('user-abc');
+  });
+});

--- a/web-client/src/services/wordService.test.ts
+++ b/web-client/src/services/wordService.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for wordService.ts — focused on the spaced repetition algorithm in finishTest.
+ * Firebase Firestore is mocked at the SDK level since wordService IS the service layer.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted ensures these vars are available when vi.mock factories run (hoisted to top)
+const {
+  mockBatchUpdate,
+  mockBatchCommit,
+  mockWriteBatch,
+  mockGetDoc,
+  mockGetDocs,
+  mockDoc,
+  mockCollection,
+  mockSetDoc,
+  mockDeleteDoc,
+  mockUpdateDoc,
+  mockQuery,
+  mockWhere,
+  mockOrderBy,
+  mockTimestampFromDate,
+  mockTimestampNow,
+} = vi.hoisted(() => {
+  const mockBatchUpdate = vi.fn();
+  const mockBatchCommit = vi.fn().mockResolvedValue(undefined);
+  const mockWriteBatch = vi.fn(() => ({
+    update: mockBatchUpdate,
+    commit: mockBatchCommit,
+  }));
+  return {
+    mockBatchUpdate,
+    mockBatchCommit,
+    mockWriteBatch,
+    mockGetDoc: vi.fn(),
+    mockGetDocs: vi.fn(),
+    mockDoc: vi.fn((_db: unknown, ...path: string[]) => ({ path: path.join('/') })),
+    mockCollection: vi.fn(),
+    mockSetDoc: vi.fn(),
+    mockDeleteDoc: vi.fn(),
+    mockUpdateDoc: vi.fn(),
+    mockQuery: vi.fn(),
+    mockWhere: vi.fn(),
+    mockOrderBy: vi.fn(),
+    mockTimestampFromDate: vi.fn((date: Date) => ({ toDate: () => date, _date: date })),
+    mockTimestampNow: vi.fn(() => ({ toDate: () => new Date() })),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  collection: mockCollection,
+  doc: mockDoc,
+  getDoc: mockGetDoc,
+  getDocs: mockGetDocs,
+  setDoc: mockSetDoc,
+  deleteDoc: mockDeleteDoc,
+  updateDoc: mockUpdateDoc,
+  query: mockQuery,
+  where: mockWhere,
+  orderBy: mockOrderBy,
+  Timestamp: {
+    fromDate: mockTimestampFromDate,
+    now: mockTimestampNow,
+  },
+  writeBatch: mockWriteBatch,
+}));
+
+vi.mock('../firebase/config', () => ({ db: {} }));
+vi.mock('./dictionaryService', () => ({
+  searchWord: vi.fn(),
+  lookupCharacter: vi.fn(),
+  lookupCharacterByTrad: vi.fn(),
+}));
+
+import { finishTest } from './wordService';
+
+// Bank intervals defined in wordService (duplicated here for assertion purposes)
+const BANK_INTERVALS: Record<number, number> = { 1: 1, 2: 3, 3: 7, 4: 30, 5: 60 };
+
+function makeFakeDoc(bank: number, simp: string, exists = true) {
+  return {
+    exists: () => exists,
+    data: () => ({
+      wordId: '1',
+      wordData: { simp, trad: simp, pinyin: 'pīn', meaning: 'meaning' },
+      amendedMeaning: null,
+      bank,
+      dueDate: { toDate: () => new Date() },
+      addedAt: { toDate: () => new Date() },
+    }),
+  };
+}
+
+describe('finishTest — spaced repetition bank logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBatchCommit.mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    });
+  });
+
+  it('advances bank by 1 when score=4 and bank < 5', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(1, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    expect(mockBatchUpdate).toHaveBeenCalledOnce();
+    const updateCall = mockBatchUpdate.mock.calls[0][1];
+    expect(updateCall.bank).toBe(2);
+  });
+
+  it('advances bank from 4 to 5 (max) when score=4', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(4, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    const updateCall = mockBatchUpdate.mock.calls[0][1];
+    expect(updateCall.bank).toBe(5);
+  });
+
+  it('does not advance bank beyond 5 when score=4 and already at max', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(5, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    const updateCall = mockBatchUpdate.mock.calls[0][1];
+    expect(updateCall.bank).toBe(5); // stays at 5
+  });
+
+  it('resets bank to 1 when score < 4 (score=3)', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(3, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 3 }]);
+
+    const updateCall = mockBatchUpdate.mock.calls[0][1];
+    expect(updateCall.bank).toBe(1);
+  });
+
+  it('resets bank to 1 from bank 5 when score < 4 (score=0)', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(5, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 0 }]);
+
+    const updateCall = mockBatchUpdate.mock.calls[0][1];
+    expect(updateCall.bank).toBe(1);
+  });
+
+  it('advances bank from 2 to 3 when score=4 (middle bank)', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(2, '学'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    const updateCall = mockBatchUpdate.mock.calls[0][1];
+    expect(updateCall.bank).toBe(3);
+  });
+
+  it('calculates due date using correct interval for new bank', async () => {
+    vi.useFakeTimers();
+    const baseDate = new Date(2026, 1, 27, 12, 0, 0); // Feb 27, 2026
+    vi.setSystemTime(baseDate);
+
+    mockGetDoc.mockResolvedValue(makeFakeDoc(1, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    // bank advances 1→2, interval for bank 2 = 3 days
+    const expectedDate = new Date(2026, 1, 27, 12, 0, 0);
+    expectedDate.setDate(expectedDate.getDate() + BANK_INTERVALS[2]);
+
+    expect(mockTimestampFromDate).toHaveBeenCalledWith(
+      expect.objectContaining({ getDate: expect.any(Function) })
+    );
+    const passedDate: Date = mockTimestampFromDate.mock.calls[0][0];
+    expect(passedDate.getDate()).toBe(expectedDate.getDate());
+    expect(passedDate.getMonth()).toBe(expectedDate.getMonth());
+
+    vi.useRealTimers();
+  });
+
+  it('calculates due date of +1 day after reset to bank 1 (score<4)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 27, 12, 0, 0));
+
+    mockGetDoc.mockResolvedValue(makeFakeDoc(4, '你好'));
+
+    await finishTest('user-1', [{ word_id: 1, score: 2 }]);
+
+    // bank resets to 1, interval = 1 day
+    const passedDate: Date = mockTimestampFromDate.mock.calls[0][0];
+    const expected = new Date(2026, 1, 27, 12, 0, 0);
+    expected.setDate(expected.getDate() + 1);
+    expect(passedDate.getDate()).toBe(expected.getDate());
+
+    vi.useRealTimers();
+  });
+
+  it('skips words whose Firestore document does not exist', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(1, '你好', false /* exists=false */));
+
+    await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns a newDates record keyed by simp with formatted date strings', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 1, 27, 12, 0, 0));
+
+    mockGetDoc.mockResolvedValue(makeFakeDoc(1, '你好'));
+
+    const newDates = await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    // Result should have the simp as key
+    expect(newDates).toHaveProperty('你好');
+    // Date format is YYYY/MM/DD
+    expect(newDates['你好']).toMatch(/^\d{4}\/\d{2}\/\d{2}$/);
+
+    vi.useRealTimers();
+  });
+
+  it('processes multiple words in a single batch', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce(makeFakeDoc(1, '你好'))
+      .mockResolvedValueOnce(makeFakeDoc(3, '谢谢'));
+
+    const scores = [
+      { word_id: 1, score: 4 },
+      { word_id: 2, score: 2 },
+    ];
+    await finishTest('user-1', scores);
+
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(2);
+    expect(mockBatchCommit).toHaveBeenCalledOnce();
+
+    const firstUpdate = mockBatchUpdate.mock.calls[0][1];
+    const secondUpdate = mockBatchUpdate.mock.calls[1][1];
+
+    expect(firstUpdate.bank).toBe(2); // 1 → 2
+    expect(secondUpdate.bank).toBe(1); // 3 → 1 (score < 4)
+  });
+
+  it('returns empty object when all word documents are missing', async () => {
+    mockGetDoc.mockResolvedValue(makeFakeDoc(1, '你好', false));
+
+    const result = await finishTest('user-1', [{ word_id: 1, score: 4 }]);
+
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
Three critical gaps covered:

1. TestLogic.ts (100% coverage): pure functions driving every test session - chooseTestSet due-date filtering, setPermList permutation building, assignQA character/pinyin/meaning mapping, toneChecker, Counter, removePunctuation.

2. wordService.finishTest (spaced repetition algorithm): bank advancement (score=4 -> bank+1, capped at 5), failure reset (score<4 -> bank=1), due-date calculation from BANK_INTERVALS, batch write, newDates return value. Firebase Firestore SDK mocked via vi.hoisted().

3. dashboardService.getDashboardStats (100% coverage): bank distribution across all 5 levels, masteredCount from bank-5 words, missing-bank fallback to 1, streak passthrough. Mocked at the service layer (wordService + streakService).

115 tests passing (was 51). Overall statement coverage: 20.84% -> 25.13%.