### PR TITLE
Add React error boundaries to component tree

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -11,6 +11,7 @@ import AddWords from './containers/AddWords/AddWords';
 import TestWords from './containers/TestWords/TestWords';
 import SettingsPage from './containers/SettingsPage/SettingsPage';
 import AuthModal from './components/Auth/AuthModal';
+import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 import * as actions from './store/actions/index';
 
 const mapDispatchToProps = {
@@ -127,13 +128,27 @@ const App: React.FC<Props> = ({
   return (
     <Box sx={{ textAlign: 'center', height: '100%' }}>
       <Layout>
-        <Switch>
-          <Route path="/" exact render={() => (isAuthenticated ? <Dashboard /> : <Home />)} />
-          <Route path="/add-words" component={AddWords} />
-          <Route path="/test-words" component={TestWords} />
-          <Route path="/settings" component={SettingsPage} />
-          <Route path="/tryout" render={() => <TestWords isDemo />} />
-        </Switch>
+        <ErrorBoundary>
+          <Switch>
+            <Route path="/" exact render={() => (
+              <ErrorBoundary>
+                {isAuthenticated ? <Dashboard /> : <Home />}
+              </ErrorBoundary>
+            )} />
+            <Route path="/add-words" render={() => (
+              <ErrorBoundary><AddWords /></ErrorBoundary>
+            )} />
+            <Route path="/test-words" render={() => (
+              <ErrorBoundary><TestWords /></ErrorBoundary>
+            )} />
+            <Route path="/settings" render={() => (
+              <ErrorBoundary><SettingsPage /></ErrorBoundary>
+            )} />
+            <Route path="/tryout" render={() => (
+              <ErrorBoundary><TestWords isDemo /></ErrorBoundary>
+            )} />
+          </Switch>
+        </ErrorBoundary>
       </Layout>
       <AuthModal />
     </Box>

--- a/web-client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/web-client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,76 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('[ErrorBoundary] Caught error:', error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '200px',
+            padding: 3,
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            Something went wrong
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            An unexpected error occurred. You can try again or return to the home page.
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <Button variant="contained" onClick={this.handleReset}>
+              Try Again
+            </Button>
+            <Button variant="outlined" href="/">
+              Go Home
+            </Button>
+          </Box>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary

Adds a generic `ErrorBoundary` component and wraps all route-level components so that a rendering crash in one page doesn't take down the entire app.

## Changes

- **New:** `web-client/src/components/ErrorBoundary/ErrorBoundary.tsx` — class component implementing `getDerivedStateFromError` + `componentDidCatch`, with a user-friendly fallback UI ("Try Again" and "Go Home" buttons)
- **Modified:** `web-client/src/App.tsx` — each route is wrapped in its own `<ErrorBoundary>`, plus an outer boundary around the `<Switch>` as a catch-all

## Design decisions

- **Per-route boundaries** so a crash in e.g. TestWords doesn't affect AddWords or Dashboard
- **Outer catch-all** boundary around the Switch in case something unexpected leaks through
- Supports optional `fallback` prop for custom error UIs and `onError` callback for future error logging integration
- Errors are logged to `console.error` for now

## Testing

All 232 existing tests pass. The ErrorBoundary is a class component (required by React's error boundary API) with a straightforward render path.

Closes #22