### PR TITLE
Add React error boundaries to component tree

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -11,6 +11,7 @@ import AddWords from './containers/AddWords/AddWords';
 import TestWords from './containers/TestWords/TestWords';
 import SettingsPage from './containers/SettingsPage/SettingsPage';
 import AuthModal from './components/Auth/AuthModal';
+import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 import * as actions from './store/actions/index';
 
 const mapDispatchToProps = {
@@ -127,13 +128,27 @@ const App: React.FC<Props> = ({
   return (
     <Box sx={{ textAlign: 'center', height: '100%' }}>
       <Layout>
-        <Switch>
-          <Route path="/" exact render={() => (isAuthenticated ? <Dashboard /> : <Home />)} />
-          <Route path="/add-words" component={AddWords} />
-          <Route path="/test-words" component={TestWords} />
-          <Route path="/settings" component={SettingsPage} />
-          <Route path="/tryout" render={() => <TestWords isDemo />} />
-        </Switch>
+        <ErrorBoundary>
+          <Switch>
+            <Route path="/" exact render={() => (
+              <ErrorBoundary>
+                {isAuthenticated ? <Dashboard /> : <Home />}
+              </ErrorBoundary>
+            )} />
+            <Route path="/add-words" render={() => (
+              <ErrorBoundary><AddWords /></ErrorBoundary>
+            )} />
+            <Route path="/test-words" render={() => (
+              <ErrorBoundary><TestWords /></ErrorBoundary>
+            )} />
+            <Route path="/settings" render={() => (
+              <ErrorBoundary><SettingsPage /></ErrorBoundary>
+            )} />
+            <Route path="/tryout" render={() => (
+              <ErrorBoundary><TestWords isDemo /></ErrorBoundary>
+            )} />
+          </Switch>
+        </ErrorBoundary>
       </Layout>
       <AuthModal />
     </Box>

--- a/web-client/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/web-client/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ErrorBoundary from './ErrorBoundary';
+
+const ThrowingComponent: React.FC<{ shouldThrow?: boolean }> = ({ shouldThrow = true }) => {
+  if (shouldThrow) {
+    throw new Error('Test render error');
+  }
+  return <div>All good</div>;
+};
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // Suppress React's error boundary console output during tests
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>Hello</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Hello')).toBeTruthy();
+  });
+
+  it('renders the default fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    expect(screen.getByText('Try Again')).toBeTruthy();
+    expect(screen.getByText('Home')).toBeTruthy();
+  });
+
+  it('renders a custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom error</div>}>
+        <ThrowingComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Custom error')).toBeTruthy();
+  });
+
+  it('calls onError when a child throws', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent />
+      </ErrorBoundary>
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message).toBe('Test render error');
+  });
+
+  it('recovers when Try Again is clicked', () => {
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+
+    // Re-render with a non-throwing child so recovery works
+    rerender(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    fireEvent.click(screen.getByText('Try Again'));
+    expect(screen.getByText('All good')).toBeTruthy();
+  });
+});

--- a/web-client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/web-client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+interface Props {
+  children: ReactNode;
+  /** Optional custom fallback UI to render on error. */
+  fallback?: ReactNode;
+  /** Called when an error is caught — use for external logging. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Generic React error boundary.
+ *
+ * Catches render-time errors in its subtree and shows a recoverable
+ * fallback UI instead of crashing the entire application.
+ */
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('[ErrorBoundary] Caught error:', error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback;
+    }
+
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 200,
+          p: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="h6" gutterBottom>
+          Something went wrong
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2, maxWidth: 360 }}>
+          An unexpected error occurred. You can try again or go back to the home page.
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button variant="contained" onClick={this.handleRetry}>
+            Try Again
+          </Button>
+          <Button variant="outlined" href="/">
+            Home
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/web-client/src/containers/Dashboard/Dashboard.tsx
+++ b/web-client/src/containers/Dashboard/Dashboard.tsx
@@ -12,6 +12,7 @@ import StreakCard from './widgets/StreakCard';
 import BankDistributionCard from './widgets/BankDistributionCard';
 import MasteryCard from './widgets/MasteryCard';
 import Chengyu from '../../components/Home/Chengyu/Chengyu';
+import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
 
 const mapStateToProps = (state: RootState) => ({
   userId: state.auth.userId,
@@ -91,7 +92,9 @@ const Dashboard: React.FC<PropsFromRedux> = ({ userId }) => {
           <MasteryCard masteredCount={stats?.masteredCount ?? 0} totalWords={stats?.totalWords ?? 0} />
         </Grid>
       </Grid>
-      <Chengyu />
+      <ErrorBoundary>
+        <Chengyu />
+      </ErrorBoundary>
     </Box>
   );
 };

--- a/web-client/src/containers/TestWords/TestWords.tsx
+++ b/web-client/src/containers/TestWords/TestWords.tsx
@@ -12,6 +12,7 @@ import SentenceRead from '../../components/Test/SentenceRead/SentenceRead';
 import NewWords from '../../components/Test/NewWords/NewWords';
 import TestSummary from '../../components/Test/TestSummary/TestSummary';
 
+import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
 import * as testLogic from '../../components/Test/Logic/TestLogic';
 import { RootState } from '../../types/store';
 import { Word, WordScore } from '../../types/models';
@@ -261,41 +262,49 @@ const TestWords: React.FC<Props> = ({
     switch (state.stage) {
       case 'new':
         content = (
-          <NewWords words={state.newWords} startTest={onStartVocab} isDemo={isDemo || !!devConfig} />
+          <ErrorBoundary>
+            <NewWords words={state.newWords} startTest={onStartVocab} isDemo={isDemo || !!devConfig} />
+          </ErrorBoundary>
         );
         break;
       case 'vocab':
         content = (
-          <Test
-            isDemo={isDemo || !!devConfig}
-            words={state.selectedWords}
-            startSentenceRead={(sentenceWords: Word[], scores?: WordScore[]) => onStartSentenceRead(sentenceWords, scores)}
-            onVocabComplete={onVocabComplete}
-            finalStage={!state.sentenceReadEnabled && !state.sentenceWriteEnabled}
-            devTestFinished={state.devTestFinished}
-            practiceMode={state.practiceMode}
-          />
+          <ErrorBoundary>
+            <Test
+              isDemo={isDemo || !!devConfig}
+              words={state.selectedWords}
+              startSentenceRead={(sentenceWords: Word[], scores?: WordScore[]) => onStartSentenceRead(sentenceWords, scores)}
+              onVocabComplete={onVocabComplete}
+              finalStage={!state.sentenceReadEnabled && !state.sentenceWriteEnabled}
+              devTestFinished={state.devTestFinished}
+              practiceMode={state.practiceMode}
+            />
+          </ErrorBoundary>
         );
 
         break;
       case 'read':
         content = (
-          <SentenceRead
-            words={state.sentenceWords}
-            startSentenceWrite={onStartSentenceWrite}
-            sentenceWriteEnabled={state.sentenceWriteEnabled}
-            isDemo={isDemo}
-          />
+          <ErrorBoundary>
+            <SentenceRead
+              words={state.sentenceWords}
+              startSentenceWrite={onStartSentenceWrite}
+              sentenceWriteEnabled={state.sentenceWriteEnabled}
+              isDemo={isDemo}
+            />
+          </ErrorBoundary>
         );
         break;
       case 'write':
         content = (
-          <SentenceWrite
-            words={state.sentenceWords}
-            seenOffsets={state.seenOffsets}
-            onComplete={onSentenceWriteComplete}
-            isDemo={isDemo}
-          />
+          <ErrorBoundary>
+            <SentenceWrite
+              words={state.sentenceWords}
+              seenOffsets={state.seenOffsets}
+              onComplete={onSentenceWriteComplete}
+              isDemo={isDemo}
+            />
+          </ErrorBoundary>
         );
         break;
       case 'summary':


### PR DESCRIPTION
## Summary

Adds a generic `ErrorBoundary` component and integrates it throughout the app so rendering errors show a recoverable fallback UI instead of a white screen crash.

## Changes

### New files
- **`ErrorBoundary.tsx`** — Class component implementing `getDerivedStateFromError` + `componentDidCatch`. Shows a "Something went wrong" message with Try Again and Home buttons. Supports optional `fallback` prop for custom error UIs and `onError` callback for logging.
- **`ErrorBoundary.test.tsx`** — 5 tests covering: normal rendering, default fallback, custom fallback, onError callback, and recovery via Try Again.

### Modified files
- **`App.tsx`** — Each route wrapped in its own `<ErrorBoundary>` plus an outer catch-all around `<Switch>`. A crash in /test-words won't affect /add-words or /settings.
- **`TestWords.tsx`** — Granular boundaries around each test stage (NewWords, Test, SentenceRead, SentenceWrite). A crash in one stage won't break the entire test flow.
- **`Dashboard.tsx`** — Boundary around `<Chengyu />` which depends on cloud functions and dictionary lookups.

## Testing

All 237 tests pass (232 existing + 5 new).

Closes #22