### PR TITLE
Filter out CL: classifier data from meanings in Test UI

### DIFF
--- a/web-client/src/components/Test/Logic/TestLogic.ts
+++ b/web-client/src/components/Test/Logic/TestLogic.ts
@@ -1,4 +1,5 @@
 import { Word, TestPerm, QuestionCategory } from '../../../types/models';
+import { parseMeanings } from '../../../utils/meaningUtils';
 
 export const chooseTestSet = (allWords: Word[], numWords: number): Word[] => {
   const today = new Date();
@@ -118,7 +119,7 @@ export const assignQA = (
     Ax = ranWord.pinyin;
     ACs = 'pinyin';
   } else {
-    Ax = ranWord.meaning.split('/');
+    Ax = parseMeanings(ranWord.meaning);
     ACs = 'meaning';
   }
 
@@ -129,7 +130,7 @@ export const assignQA = (
     Qx = ranWord.pinyin;
     QCs = 'pinyin';
   } else {
-    Qx = ranWord.meaning.split('/');
+    Qx = parseMeanings(ranWord.meaning);
     QCs = 'meaning';
   }
 

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
@@ -25,6 +25,7 @@ import { Word } from '../../../types/models';
 import { AppDispatch } from '../../../types/actions';
 import { searchWord } from '../../../services/dictionaryService';
 import { getSegmentedSentence } from '../../../services/sentenceService';
+import { parseMeanings } from '../../../utils/meaningUtils';
 
 const beep = new Howl({ src: [successSound], volume: 0.5 });
 const fail = new Howl({ src: [failSound], volume: 0.7 });
@@ -584,7 +585,7 @@ const SentenceRead: React.FC<Props> = ({
               <Typography variant="subtitle2" sx={{ m: 0, fontWeight: 'bold' }}>Pinyin:</Typography>
               <Typography variant="body2">{word.pinyin}</Typography>
               <Typography variant="subtitle2" sx={{ m: 0, fontWeight: 'bold' }}>Meaning:</Typography>
-              <Typography variant="body2">{word.meaning.split('/').join(' / ')}</Typography>
+              <Typography variant="body2">{parseMeanings(word.meaning).join(' / ')}</Typography>
               {addedWords.find((aw) => aw.id === word.id) ? (
                 <Button disabled>Added!</Button>
               ) : (

--- a/web-client/src/components/TestChengyusTest/TestChengyusTest.tsx
+++ b/web-client/src/components/TestChengyusTest/TestChengyusTest.tsx
@@ -7,6 +7,7 @@ import Button from '../UI/Buttons/Button/Button';
 
 import { RootState } from '../../types/store';
 import { Word } from '../../types/models';
+import { parseMeanings } from '../../utils/meaningUtils';
 
 interface CharData {
   simp: string;
@@ -162,7 +163,7 @@ const TestChengyusTest: React.FC<Props> = ({
       <>
         <Typography sx={{ fontSize: '3em', m: 0 }}>{state.charData.simp}</Typography>
         <Typography sx={{ fontSize: '1.5em', m: 0 }}>({state.charData.pinyins.join('/')})</Typography>
-        <Typography sx={{ fontSize: '1.1em', m: 0 }}>{state.charData.meanings.join(' / ')}</Typography>
+        <Typography sx={{ fontSize: '1.1em', m: 0 }}>{state.charData.meanings.filter((m) => !m.startsWith('CL:')).join(' / ')}</Typography>
       </>
     );
   }
@@ -213,7 +214,7 @@ const TestChengyusTest: React.FC<Props> = ({
         {state.showChengyuMeaning ? (
           <>
             <p style={{ fontSize: '0.6em' }}>({words[state.wordIndex].pinyin})</p>
-            <p style={{ fontSize: '1.1em' }}>{words[state.wordIndex].meaning}</p>
+            <p style={{ fontSize: '1.1em' }}>{parseMeanings(words[state.wordIndex].meaning).join(' / ')}</p>
           </>
         ) : null}
       </Paper>


### PR DESCRIPTION
Use parseMeanings() utility in TestLogic, SentenceRead popup, and TestChengyusTest to strip classifier entries (CL:...) that were already filtered in the AddWords interface but still appeared during tests.

Closes #32

https://claude.ai/code/session_01WRTcxhsPGSLczAqyh26Mhc