### PR TITLE
Remove DeepL Translation function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,6 @@ Security rules in [firestore.rules](firestore.rules): users can only access thei
 #### Cloud Functions
 
 [functions/src/index.ts](functions/src/index.ts) - Callable functions for server-side operations:
-- `translateWithDeepL` - Translation with server-side API key
 - `getDailyChengyu` - Rotates through chengyus daily
 - `lookupChengyuChar` - Character details for chengyu quiz
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@google-cloud/translate": "^8.0.0",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.5.0"
   },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,11 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
-import { Translate } from '@google-cloud/translate/build/src/v2';
 
 admin.initializeApp();
-
-// Initialize Google Cloud Translation client
-const translate = new Translate();
 
 const db = admin.firestore();
 
@@ -21,41 +17,6 @@ function verifyAuth(context: functions.https.CallableContext): string {
   }
   return context.auth.uid;
 }
-
-/**
- * Translate text using Google Cloud Translation API
- * Keeps the same function name for frontend compatibility
- */
-export const translateWithDeepL = functions.https.onCall(
-  async (data: { text: string; targetLang: string }, context) => {
-    verifyAuth(context);
-
-    const { text, targetLang } = data;
-
-    if (!text || !targetLang) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'text and targetLang are required'
-      );
-    }
-
-    // Map DeepL language codes to Google codes
-    const googleLang = targetLang === 'EN' ? 'en' : 'zh-CN';
-
-    try {
-      const [translation] = await translate.translate(text, googleLang);
-
-      // Return in same format as DeepL for frontend compatibility
-      return { translations: [{ text: translation }] };
-    } catch (error) {
-      console.error('Google Translation error:', error);
-      throw new functions.https.HttpsError(
-        'internal',
-        'Translation failed'
-      );
-    }
-  }
-);
 
 /**
  * Get the daily chengyu challenge

--- a/scripts/create-tech-debt-issues.sh
+++ b/scripts/create-tech-debt-issues.sh
@@ -171,44 +171,5 @@ ISSUE_EOF
 )"
 echo "✓ Issue 4 created: Memoization"
 
-# --- Issue 5: Rate Limiting ---
-gh issue create --repo "$REPO" \
-  --title "Add rate limiting to Cloud Functions (translateWithDeepL)" \
-  --body "$(cat <<'ISSUE_EOF'
-## Problem
-
-The `translateWithDeepL` Cloud Function (`functions/src/index.ts:29-58`) has no rate limiting or request size limits. While it does verify authentication (line 31), any authenticated user can call it as frequently as they want.
-
-### Specific Gaps
-
-- No per-user rate limiting on translation requests
-- No input size validation (text field length is unchecked beyond non-empty check)
-- No daily/monthly quota per user
-- Translation API costs are borne by the project — a single user could generate significant costs
-
-## Impact
-
-- **Cost risk**: An authenticated user (or compromised account) could rack up translation API charges
-- **Abuse**: Automated scripts could use the endpoint as a free translation proxy
-- **Availability**: High call volume from one user could affect others
-
-## Proposed Solution
-
-1. Add per-user rate limiting (e.g., 50 translations/hour) using Firestore counters or Firebase Rate Limiter extension
-2. Add input size validation (e.g., max 500 characters per request)
-3. Consider adding a daily translation quota per user
-4. Log translation usage for monitoring
-
-## Files Affected
-
-- `functions/src/index.ts` — translateWithDeepL function
-
-## Priority
-
-Medium — low probability but high potential impact. Simple to implement.
-ISSUE_EOF
-)"
-echo "✓ Issue 5 created: Rate limiting"
-
 echo
-echo "All 5 issues created successfully!"
+echo "All 4 issues created successfully!"


### PR DESCRIPTION
## Summary

Removes the unused `translateWithDeepL` Cloud Function and all related code. The function was originally a DeepL translation wrapper, later migrated to Google Cloud Translation API, but is **not called anywhere in the frontend**. Removing it eliminates dead code, reduces the Cloud Functions bundle size, and removes unnecessary API cost exposure.

## Changes

- **`functions/src/index.ts`** — Removed the `translateWithDeepL` export, the `@google-cloud/translate` import, and the `Translate` client initialization. The `verifyAuth` helper and remaining functions (`getDailyChengyu`, `lookupChengyuChar`) are unchanged.
- **`functions/package.json`** — Removed the `@google-cloud/translate` dependency.
- **`CLAUDE.md`** — Removed the `translateWithDeepL` line from the Cloud Functions documentation.
- **`scripts/create-tech-debt-issues.sh`** — Removed Issue #5 (rate limiting for `translateWithDeepL`) since the function no longer exists. Updated the final summary from "5 issues" to "4 issues".

## Verification

- Searched the entire frontend codebase (`web-client/`) for any references to `translateWithDeepL`, `translate`, or DeepL — **no frontend code calls this function**.
- The only translation-related strings in frontend components are UI labels (e.g., "Your translation" in `SentenceRead.tsx`) and a Material UI icon import, neither of which invoke the Cloud Function.
- The legacy Flask backend (`api/`) has its own translation endpoint but is documented as no longer in use.

## Decisions

- Removed the entire tech debt Issue #5 from the script rather than repurposing it, since it was entirely about rate-limiting the now-removed function.
- Left the `verifyAuth` helper in place since it's still used by `getDailyChengyu` and `lookupChengyuChar`.

Closes #56

---
Closes #56