### PR TITLE
[Tech Debt] Home.tsx makes redundant Firestore reads alongside Redux initWords

### DIFF
--- a/web-client/src/containers/Home/Home.tsx
+++ b/web-client/src/containers/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
@@ -13,12 +13,13 @@ import FeatureHighlights from '../../components/Home/FeatureHighlights/FeatureHi
 
 import * as actions from '../../store/actions/index';
 import { RootState } from '../../types/store';
-import * as wordService from '../../services/wordService';
 
 const mapStateToProps = (state: RootState) => ({
   isAuthenticated: state.auth.userId !== null,
   userId: state.auth.userId,
   lang: state.settings.lang,
+  words: state.addWords.words,
+  wordsLoading: state.addWords.loading,
 });
 
 const mapDispatchToProps = {
@@ -33,41 +34,29 @@ type Props = PropsFromRedux & RouteComponentProps;
 const Home: React.FC<Props> = ({
   isAuthenticated,
   userId,
+  words,
+  wordsLoading,
   onInitWords,
   onOpenAuthModal,
   history,
 }) => {
-  const [numDue, setNumDue] = useState(0);
-  const [numTot, setNumTot] = useState(0);
-  const [statsLoading, setStatsLoading] = useState(false);
-
-  const getDueWords = useCallback(async (): Promise<void> => {
-    if (!userId) return;
-    try {
-      const dueWords = await wordService.getDueUserWords(userId);
-      setNumDue(dueWords.length);
-    } catch (error) {
-      console.error('Failed to get due words:', error);
-    }
-  }, [userId]);
-
-  const getUserWords = useCallback(async (): Promise<void> => {
-    if (!userId) return;
-    try {
-      const words = await wordService.getUserWords(userId);
-      setNumTot(words.length);
-    } catch (error) {
-      console.error('Failed to get user words:', error);
-    }
-  }, [userId]);
+  const numTot = words.length;
+  const numDue = useMemo(() => {
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    return words.filter((w) => {
+      if (!w.due_date) return true;
+      const due = new Date(w.due_date);
+      due.setHours(0, 0, 0, 0);
+      return due <= now;
+    }).length;
+  }, [words]);
 
   useEffect(() => {
     if (isAuthenticated && userId) {
-      setStatsLoading(true);
-      Promise.all([getDueWords(), getUserWords()]).finally(() => setStatsLoading(false));
       onInitWords();
     }
-  }, [getDueWords, getUserWords, isAuthenticated, onInitWords, userId]);
+  }, [isAuthenticated, onInitWords, userId]);
 
   const onClickSignUp = (): void => {
     onOpenAuthModal('register');
@@ -92,7 +81,7 @@ const Home: React.FC<Props> = ({
           numDue={numDue}
           numTot={numTot}
           testClicked={onTestClicked}
-          loading={statsLoading}
+          loading={wordsLoading}
         />
       )}
       {isAuthenticated && <Chengyu />}


### PR DESCRIPTION
## Summary

Removes redundant Firestore reads from `Home.tsx` by deriving word stats (`numDue`, `numTot`) from Redux state instead of making direct service calls.

Previously, `Home.tsx` made **3 Firestore queries** on every authenticated page load:
1. `wordService.getDueUserWords(userId)` — direct service call for due word count
2. `wordService.getUserWords(userId)` — direct service call for total word count
3. `onInitWords()` — Redux action that also calls `getUserWords`

Now it makes just **1 query** via `onInitWords()`, and derives stats from the store.

## Key implementation details

- `numTot` is simply `words.length` from `state.addWords.words`
- `numDue` is computed via `useMemo`, filtering words where `due_date <= today` (words with no `due_date` are counted as due)
- Loading state uses `state.addWords.loading` instead of local `statsLoading` state
- Removed the `wordService` import entirely from the container — it now only interacts with Redux

## Decisions / trade-offs

- Words with no `due_date` are treated as due (same behavior as the original `getDueUserWords` service call which filters server-side)
- Date comparison is done at day granularity (hours zeroed out) to match the spaced repetition system's day-based intervals
- The `useMemo` recomputes only when the `words` array reference changes, which is efficient since Redux returns a new array only on actual data changes

## Files modified

- `web-client/src/containers/Home/Home.tsx` — replaced direct service calls with Redux state derivation

Closes #70

---
Closes #70