### PR TITLE
Taller summary table

### DIFF
--- a/web-client/src/components/Test/TestSummary/TestSummary.tsx
+++ b/web-client/src/components/Test/TestSummary/TestSummary.tsx
@@ -37,7 +37,7 @@ const TestSummary: React.FC<TestSummaryProps> = ({ history, scores }) => {
 
       <Box
         sx={{
-          maxHeight: { xs: 220, sm: 280 },
+          maxHeight: { xs: 'calc(100vh - 280px)', sm: 'calc(100vh - 320px)' },
           overflowY: 'auto',
           mx: { xs: 0, sm: 2 },
           mb: 3,


### PR DESCRIPTION
## Summary
- The session summary table after testing was too short on mobile, showing only ~220px of scrollable content
- Replaced fixed `maxHeight` values with viewport-relative `calc(100vh - 280px)` (mobile) and `calc(100vh - 320px)` (desktop) so the score list fills most of the available screen space
- The 280px/320px offsets account for the stepper, heading, subtitle, home button, and padding

## Key implementation details
- Single line change in `TestSummary.tsx` — the `maxHeight` on the scrollable score list `Box`
- Uses `calc(100vh - ...)` to be responsive to any screen size rather than hardcoded pixel values
- The list remains scrollable via `overflowY: 'auto'` for sessions with many words

## Files modified
- `web-client/src/components/Test/TestSummary/TestSummary.tsx` — changed `maxHeight` from `{ xs: 220, sm: 280 }` to `{ xs: 'calc(100vh - 280px)', sm: 'calc(100vh - 320px)' }`

Closes #89

---
Closes #89