### PR TITLE
Sidebar redesign

### DIFF
--- a/web-client/src/components/Navigation/NavigationItems/NavigationItems.tsx
+++ b/web-client/src/components/Navigation/NavigationItems/NavigationItems.tsx
@@ -40,30 +40,54 @@ const NavigationItems: React.FC<Props> = (props) => {
         { to: '/settings', label: 'Settings' },
       ];
 
+      const drawerItemSx = {
+        color: 'rgba(255,255,255,0.7)',
+        borderRadius: 2,
+        py: 1.2,
+        '&:hover': {
+          backgroundColor: 'rgba(255,255,255,0.1)',
+          color: 'common.white',
+        },
+        '&.active': {
+          backgroundColor: 'rgba(255,255,255,0.15)',
+          color: 'common.white',
+          fontWeight: 600,
+        },
+      };
+
       return (
-        <List>
+        <List sx={{ px: 1 }}>
           {links.map((link) => (
-            <ListItem key={link.to} disablePadding>
+            <ListItem key={link.to} disablePadding sx={{ mb: 0.5 }}>
               <ListItemButton
                 component={NavLink}
                 to={link.to}
                 exact
-                sx={{
-                  color: 'common.white',
-                  '&.active': { color: 'primary.main' },
-                }}
+                onClick={() => props.drawerClosed?.()}
+                sx={drawerItemSx}
               >
-                <ListItemText primary={link.label} />
+                <ListItemText
+                  primary={link.label}
+                  primaryTypographyProps={{ fontWeight: 'inherit' }}
+                />
               </ListItemButton>
             </ListItem>
           ))}
-          <ListItem disablePadding>
+          <ListItem disablePadding sx={{ mb: 0.5 }}>
             <ListItemButton
               onClick={() => {
                 props.onLogout();
                 props.drawerClosed?.();
               }}
-              sx={{ color: 'common.white' }}
+              sx={{
+                color: 'rgba(255,255,255,0.7)',
+                borderRadius: 2,
+                py: 1.2,
+                '&:hover': {
+                  backgroundColor: 'rgba(255,255,255,0.1)',
+                  color: 'common.white',
+                },
+              }}
             >
               <ListItemText primary="Logout" />
             </ListItemButton>
@@ -74,41 +98,70 @@ const NavigationItems: React.FC<Props> = (props) => {
 
     const unauthLinks = [{ to: '/', label: 'Home' }];
 
+    const drawerItemSx = {
+      color: 'rgba(255,255,255,0.7)',
+      borderRadius: 2,
+      py: 1.2,
+      '&:hover': {
+        backgroundColor: 'rgba(255,255,255,0.1)',
+        color: 'common.white',
+      },
+      '&.active': {
+        backgroundColor: 'rgba(255,255,255,0.15)',
+        color: 'common.white',
+        fontWeight: 600,
+      },
+    };
+
     return (
-      <List>
+      <List sx={{ px: 1 }}>
         {unauthLinks.map((link) => (
-          <ListItem key={link.to} disablePadding>
+          <ListItem key={link.to} disablePadding sx={{ mb: 0.5 }}>
             <ListItemButton
               component={NavLink}
               to={link.to}
               exact
-              sx={{
-                color: 'common.white',
-                '&.active': { color: 'primary.main' },
-              }}
+              onClick={() => props.drawerClosed?.()}
+              sx={drawerItemSx}
             >
               <ListItemText primary={link.label} />
             </ListItemButton>
           </ListItem>
         ))}
-        <ListItem disablePadding>
+        <ListItem disablePadding sx={{ mb: 0.5 }}>
           <ListItemButton
             onClick={() => {
               props.onOpenAuthModal('login');
               props.drawerClosed?.();
             }}
-            sx={{ color: 'common.white' }}
+            sx={{
+              color: 'rgba(255,255,255,0.7)',
+              borderRadius: 2,
+              py: 1.2,
+              '&:hover': {
+                backgroundColor: 'rgba(255,255,255,0.1)',
+                color: 'common.white',
+              },
+            }}
           >
             <ListItemText primary="Login" />
           </ListItemButton>
         </ListItem>
-        <ListItem disablePadding>
+        <ListItem disablePadding sx={{ mb: 0.5 }}>
           <ListItemButton
             onClick={() => {
               props.onOpenAuthModal('register');
               props.drawerClosed?.();
             }}
-            sx={{ color: 'common.white' }}
+            sx={{
+              color: 'rgba(255,255,255,0.7)',
+              borderRadius: 2,
+              py: 1.2,
+              '&:hover': {
+                backgroundColor: 'rgba(255,255,255,0.1)',
+                color: 'common.white',
+              },
+            }}
           >
             <ListItemText primary="Register" />
           </ListItemButton>

--- a/web-client/src/components/Navigation/SideDrawer/SideDrawer.tsx
+++ b/web-client/src/components/Navigation/SideDrawer/SideDrawer.tsx
@@ -20,9 +20,9 @@ const SideDrawer: React.FC<SideDrawerProps> = (props) => {
       sx={{
         display: { sm: 'none' },
         '& .MuiDrawer-paper': {
-          width: 200,
+          width: 240,
           maxWidth: '70%',
-          backgroundColor: 'primary.main',
+          backgroundColor: 'primary.dark',
         },
       }}
     >

--- a/web-client/src/components/Navigation/Sidebar/Sidebar.tsx
+++ b/web-client/src/components/Navigation/Sidebar/Sidebar.tsx
@@ -45,39 +45,73 @@ const Sidebar: React.FC<PropsFromRedux> = ({ onLogout }) => {
         '& .MuiDrawer-paper': {
           width: SIDEBAR_WIDTH,
           boxSizing: 'border-box',
-          backgroundColor: colors.primary,
-          borderRight: `1px solid ${colors.divider}`,
+          backgroundColor: colors.primaryDark,
+          borderRight: 'none',
           top: 56,
           height: 'calc(100% - 56px)',
         },
       }}
     >
-      <Box component="nav" aria-label="Main navigation" sx={{ overflow: 'auto' }}>
-        <List>
+      <Box
+        component="nav"
+        aria-label="Main navigation"
+        sx={{
+          overflow: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          pt: 1,
+        }}
+      >
+        <List sx={{ flex: 1, px: 1 }}>
           {links.map((link) => (
-            <ListItem key={link.to} disablePadding>
+            <ListItem key={link.to} disablePadding sx={{ mb: 0.5 }}>
               <ListItemButton
                 component={NavLink}
                 to={link.to}
                 exact
                 sx={{
-                  color: colors.text,
+                  color: 'rgba(255,255,255,0.7)',
+                  borderRadius: 2,
+                  py: 1.2,
+                  '&:hover': {
+                    backgroundColor: 'rgba(255,255,255,0.1)',
+                    color: colors.white,
+                  },
                   '&.active': {
-                    backgroundColor: 'rgba(0,0,0,0.08)',
-                    borderRight: `3px solid ${colors.primaryDark}`,
+                    backgroundColor: 'rgba(255,255,255,0.15)',
+                    color: colors.white,
+                    fontWeight: 600,
+                    '& .MuiListItemIcon-root': {
+                      color: colors.primary,
+                    },
                   },
                 }}
               >
                 <ListItemIcon sx={{ color: 'inherit', minWidth: 40 }}>{link.icon}</ListItemIcon>
-                <ListItemText primary={link.label} />
+                <ListItemText
+                  primary={link.label}
+                  primaryTypographyProps={{ fontWeight: 'inherit' }}
+                />
               </ListItemButton>
             </ListItem>
           ))}
         </List>
-        <Divider />
-        <List>
+        <Divider sx={{ borderColor: 'rgba(255,255,255,0.15)', mx: 1 }} />
+        <List sx={{ px: 1, pb: 1 }}>
           <ListItem disablePadding>
-            <ListItemButton onClick={onLogout} sx={{ color: colors.text }}>
+            <ListItemButton
+              onClick={onLogout}
+              sx={{
+                color: 'rgba(255,255,255,0.7)',
+                borderRadius: 2,
+                py: 1.2,
+                '&:hover': {
+                  backgroundColor: 'rgba(255,255,255,0.1)',
+                  color: colors.white,
+                },
+              }}
+            >
               <ListItemIcon sx={{ color: 'inherit', minWidth: 40 }}>
                 <LogoutIcon />
               </ListItemIcon>


### PR DESCRIPTION
## Summary

Redesigns the sidebar navigation to fix the poor contrast between active/selected links and the background. The sidebar now uses a dark green (`primaryDark` / `#1a5c40`) background instead of the beige (`#efdece`), making navigation state immediately clear.

**Before:** Beige sidebar with nearly invisible active state (`rgba(0,0,0,0.08)` on `#efdece` background)
**After:** Dark green sidebar with white text, distinct active/hover states, and rounded nav items

## Key changes

- **Desktop Sidebar** (`Sidebar.tsx`): Dark green background, white text at 70% opacity (inactive) / 100% (active/hover), rounded `borderRadius: 2` items, active items highlighted with `rgba(255,255,255,0.15)` background and beige icon accent, subtle translucent divider
- **Mobile SideDrawer** (`SideDrawer.tsx`): Matched to desktop sidebar — dark green background, wider drawer (240px vs 200px)
- **NavigationItems** (`NavigationItems.tsx`): Updated mobile drawer nav items with matching rounded style, hover/active states, and consistent spacing; also closes drawer on nav link click for better UX

## Decisions

- Used the existing `primaryDark` color (`#1a5c40`) rather than introducing new colors, keeping the palette consistent
- Active nav icons use the beige (`colors.primary`) as an accent on the dark background — a nice inversion of the color hierarchy
- Kept the same 240px sidebar width and 56px toolbar offset
- Mobile drawer width increased from 200px to 240px to match desktop sidebar width

## Files modified

- `web-client/src/components/Navigation/Sidebar/Sidebar.tsx` — Desktop sidebar styling overhaul
- `web-client/src/components/Navigation/SideDrawer/SideDrawer.tsx` — Mobile drawer background and width
- `web-client/src/components/Navigation/NavigationItems/NavigationItems.tsx` — Mobile drawer nav item styling

---
Closes #99