### PR TITLE
Fix the test words on a given day.

### DIFF
--- a/web-client/src/components/Test/Logic/TestLogic.test.ts
+++ b/web-client/src/components/Test/Logic/TestLogic.test.ts
@@ -85,6 +85,63 @@ describe('chooseTestSet', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('is deterministic across repeated calls', () => {
+    const words = Array.from({ length: 10 }, (_, i) => makeWord(i, `字${i}`, '2026/02/20'));
+    const result1 = chooseTestSet(words, 5);
+    const result2 = chooseTestSet(words, 5);
+    expect(result1.map((w) => w.id)).toEqual(result2.map((w) => w.id));
+  });
+
+  it('selects oldest due dates first', () => {
+    const words = [
+      makeWord(1, '一', '2026/02/25'),
+      makeWord(2, '二', '2026/02/20'),
+      makeWord(3, '三', '2026/02/22'),
+      makeWord(4, '四', '2026/02/18'),
+      makeWord(5, '五', '2026/02/26'),
+    ];
+    const result = chooseTestSet(words, 3);
+    const ids = result.map((w) => w.id);
+    // Should pick the 3 oldest: ids 4 (Feb 18), 2 (Feb 20), 3 (Feb 22)
+    expect(ids.sort()).toEqual([2, 3, 4]);
+  });
+
+  it('breaks ties deterministically within a day', () => {
+    const words = Array.from({ length: 10 }, (_, i) => makeWord(i, `字${i}`, '2026/02/20'));
+    const results = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      const result = chooseTestSet(words, 5);
+      results.add(result.map((w) => w.id).join(','));
+    }
+    // All calls on the same day should return the same set
+    expect(results.size).toBe(1);
+  });
+
+  it('tie-breaking may change on a different day', () => {
+    const words = Array.from({ length: 20 }, (_, i) => makeWord(i, `字${i}`, '2026/02/20'));
+    const result1 = chooseTestSet(words, 5);
+    vi.setSystemTime(new Date(2026, 1, 28, 10, 0, 0));
+    const result2 = chooseTestSet(words, 5);
+    // With 20 words and only picking 5, different days should very likely differ
+    const ids1 = result1.map((w) => w.id).join(',');
+    const ids2 = result2.map((w) => w.id).join(',');
+    expect(ids1).not.toEqual(ids2);
+  });
+
+  it('selects definite words plus deterministic ties', () => {
+    const yesterday = Array.from({ length: 3 }, (_, i) => makeWord(i, `昨${i}`, '2026/02/26'));
+    const today = Array.from({ length: 5 }, (_, i) => makeWord(i + 3, `今${i}`, '2026/02/27'));
+    const words = [...yesterday, ...today];
+    const result = chooseTestSet(words, 5);
+    // All 3 from yesterday should be included
+    const resultIds = result.map((w) => w.id);
+    expect(resultIds).toContain(0);
+    expect(resultIds).toContain(1);
+    expect(resultIds).toContain(2);
+    // Plus 2 from today's tie group
+    expect(result).toHaveLength(5);
+  });
+
   it('correctly parses slash-separated dates (Safari compatibility)', () => {
     // Safari returns Invalid Date for new Date('YYYY/MM/DD'); parseDueDate must
     // split the string manually so words are selected on iOS.

--- a/web-client/src/components/Test/Logic/TestLogic.ts
+++ b/web-client/src/components/Test/Logic/TestLogic.ts
@@ -35,6 +35,34 @@ function parseDueDate(dateStr: string): Date | null {
   return new Date(year, month - 1, day);
 }
 
+function seedFromDate(date: Date): number {
+  const str = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+function seededShuffle<T>(array: T[], seed: number): T[] {
+  const result = [...array];
+  let s = seed;
+  const next = () => {
+    s = (s * 1664525 + 1013904223) | 0;
+    return (s >>> 0) / 0x100000000;
+  };
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+function dueDateDay(dateStr: string): number {
+  const d = parseDueDate(dateStr)!;
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
 export const chooseTestSet = (allWords: Word[], numWords: number): Word[] => {
   const today = new Date();
   const dueWords = allWords.filter((word) => {
@@ -42,7 +70,34 @@ export const chooseTestSet = (allWords: Word[], numWords: number): Word[] => {
     const due = parseDueDate(word.due_date);
     return due !== null && due <= today;
   });
-  return pickRandom(dueWords, numWords);
+
+  if (dueWords.length <= numWords) {
+    return dueWords;
+  }
+
+  // Sort by due date ascending (oldest due first)
+  dueWords.sort((a, b) => dueDateDay(a.due_date!) - dueDateDay(b.due_date!));
+
+  // Find the cutoff date (the due date of the last word we'd take)
+  const cutoffTime = dueDateDay(dueWords[numWords - 1].due_date!);
+
+  const definitelyIn: Word[] = [];
+  const tieGroup: Word[] = [];
+
+  for (const word of dueWords) {
+    const dayTime = dueDateDay(word.due_date!);
+    if (dayTime < cutoffTime) {
+      definitelyIn.push(word);
+    } else if (dayTime === cutoffTime) {
+      tieGroup.push(word);
+    }
+  }
+
+  const remaining = numWords - definitelyIn.length;
+  const seed = seedFromDate(today);
+  const shuffledTies = seededShuffle(tieGroup, seed);
+
+  return [...definitelyIn, ...shuffledTies.slice(0, remaining)];
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes #120 — test words are now chosen deterministically on a given day instead of randomly.

Previously, `chooseTestSet()` used `pickRandom()` (Fisher-Yates with `Math.random()`), meaning a page refresh could show different words mid-test. Now:

- Due words are sorted by due date ascending (oldest/most overdue first)
- Words with strictly older due dates are always selected first
- Ties (same due date) are broken using a **date-seeded PRNG** — a simple LCG seeded with a hash of today's date — so the same tie group produces the same selection all day, but may vary across days

## Key implementation details

- **`seedFromDate()`** — hashes `YYYY-M-D` string via djb2 to produce a numeric seed
- **`seededShuffle()`** — Fisher-Yates shuffle using a linear congruential generator (LCG) instead of `Math.random()`
- **`chooseTestSet()`** rewritten to: filter due words → sort by due date → split into "definitelyIn" (before cutoff date) and "tieGroup" (at cutoff date) → seeded-shuffle the tie group → take remaining slots from it
- **`chooseRandomTestSet()`** and **`pickRandom()`** left unchanged — practice mode should remain random

## Decisions and trade-offs

- No external PRNG library — the djb2 + LCG combo is simple, deterministic, and sufficient for non-cryptographic shuffling
- Sorting is O(n log n) vs previous O(n) random pick, but n is a user's due word list (typically <100), so negligible
- If a user adds new due words mid-day, the selection may change — this is acceptable and arguably correct

## Tests added

- **Deterministic across calls** — same inputs + same day → identical results
- **Oldest due dates first** — verifies priority ordering
- **Tie-breaking deterministic within a day** — repeated calls return same set
- **Tie-breaking changes across days** — different day seed produces different selection
- **Mixed dates** — definite selections + deterministic tie-breaking combined

All 700 tests pass.

## Files modified

- `web-client/src/components/Test/Logic/TestLogic.ts` — rewrote `chooseTestSet()`, added `seedFromDate()`, `seededShuffle()`, `dueDateDay()` helpers
- `web-client/src/components/Test/Logic/TestLogic.test.ts` — added 5 new tests for deterministic behavior

---
Closes #120