### PR TITLE
Separate settings option for sound effect

### DIFF
--- a/web-client/src/components/Settings/Settings.test.tsx
+++ b/web-client/src/components/Settings/Settings.test.tsx
@@ -95,12 +95,12 @@ describe('Settings — character set radio buttons', () => {
 });
 
 describe('Settings — checkbox toggles', () => {
-  it('toggling Sound checkbox persists to localStorage', async () => {
+  it('toggling Text-to-speech checkbox persists to localStorage', async () => {
     const user = userEvent.setup();
     // synthAvailable=true so checkbox is enabled
     renderWithProviders(<Settings />, { store: makeStore(false, true) });
 
-    const soundCheckbox = screen.getByRole('checkbox', { name: /^sound$/i });
+    const soundCheckbox = screen.getByRole('checkbox', { name: /text-to-speech/i });
     // Default is checked (true), clicking unchecks
     await user.click(soundCheckbox);
     expect(localStorage.getItem('useSound')).toBe('false');
@@ -219,15 +219,15 @@ describe('Settings — priority radio buttons', () => {
 });
 
 describe('Settings — speech availability gating', () => {
-  it('disables Sound checkbox when synthAvailable is false', () => {
+  it('disables Text-to-speech checkbox when synthAvailable is false', () => {
     renderWithProviders(<Settings />, { store: makeStore(false, false) });
-    const soundCheckbox = screen.getByRole('checkbox', { name: /^sound$/i });
+    const soundCheckbox = screen.getByRole('checkbox', { name: /text-to-speech/i });
     expect(soundCheckbox).toBeDisabled();
   });
 
-  it('enables Sound checkbox when synthAvailable is true', () => {
+  it('enables Text-to-speech checkbox when synthAvailable is true', () => {
     renderWithProviders(<Settings />, { store: makeStore(false, true) });
-    const soundCheckbox = screen.getByRole('checkbox', { name: /^sound$/i });
+    const soundCheckbox = screen.getByRole('checkbox', { name: /text-to-speech/i });
     expect(soundCheckbox).not.toBeDisabled();
   });
 

--- a/web-client/src/components/Settings/Settings.tsx
+++ b/web-client/src/components/Settings/Settings.tsx
@@ -21,6 +21,7 @@ interface SettingsState {
   useEnglishSpeechRecognition: boolean;
   useHandwriting: boolean;
   useSound: boolean;
+  useSoundEffects: boolean;
   useAutoRecord: boolean;
   useFlashcards: boolean;
   newWords: boolean;
@@ -84,6 +85,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
     const useEnglishSpeechRecognition = localStorage.getItem('useEnglishSpeechRecognition');
     const useHandwriting = localStorage.getItem('useHandwriting');
     const useSound = localStorage.getItem('useSound');
+    const useSoundEffects = localStorage.getItem('useSoundEffects');
     const useAutoRecord = localStorage.getItem('useAutoRecord');
     const useFlashcards = localStorage.getItem('useFlashcards');
     const newWords = localStorage.getItem('newWords');
@@ -99,6 +101,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
       useEnglishSpeechRecognition: useEnglishSpeechRecognition === 'false' ? false : true,
       useHandwriting: useHandwriting === 'false' ? false : true,
       useSound: useSound === 'false' ? false : true,
+      useSoundEffects: useSoundEffects === 'false' ? false : true,
       useAutoRecord: useAutoRecord === 'false' ? false : true,
       useFlashcards: useFlashcards === 'false' ? false : true,
       newWords: newWords === 'false' ? false : true,
@@ -184,10 +187,17 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
   const checkboxItems = [
     {
       value: 'useSound',
-      label: 'Sound',
+      label: 'Text-to-speech',
       checked: state.useSound && synthAvailable,
       disabled: !synthAvailable,
       disabledTooltip: 'Speech synthesis is not available in this browser',
+    },
+    {
+      value: 'useSoundEffects',
+      label: 'Sound effects',
+      checked: state.useSoundEffects,
+      disabled: false,
+      disabledTooltip: '',
     },
     {
       value: 'useChineseSpeechRecognition',

--- a/web-client/src/components/Test/AudioSettingsDrawer/AudioSettingsDrawer.test.tsx
+++ b/web-client/src/components/Test/AudioSettingsDrawer/AudioSettingsDrawer.test.tsx
@@ -19,7 +19,8 @@ describe('AudioSettingsDrawer', () => {
 
   it('renders all audio setting checkboxes when open', () => {
     render(<AudioSettingsDrawer {...defaultProps} />);
-    expect(screen.getByText('Sound')).toBeInTheDocument();
+    expect(screen.getByText('Text-to-speech')).toBeInTheDocument();
+    expect(screen.getByText('Sound effects')).toBeInTheDocument();
     expect(screen.getByText('Chinese speech recognition')).toBeInTheDocument();
     expect(screen.getByText('English speech recognition')).toBeInTheDocument();
     expect(screen.getByText('Automatic recording')).toBeInTheDocument();
@@ -31,10 +32,10 @@ describe('AudioSettingsDrawer', () => {
     expect(screen.getByText('Audio & Voice Settings')).toBeInTheDocument();
   });
 
-  it('disables sound checkbox when synthAvailable is false', () => {
+  it('disables text-to-speech checkbox when synthAvailable is false', () => {
     render(<AudioSettingsDrawer {...defaultProps} synthAvailable={false} />);
-    const soundCheckbox = screen.getByRole('checkbox', { name: /^Sound/ });
-    expect(soundCheckbox).toBeDisabled();
+    const ttsCheckbox = screen.getByRole('checkbox', { name: /^Text-to-speech/ });
+    expect(ttsCheckbox).toBeDisabled();
   });
 
   it('disables speech recognition checkboxes when speechAvailable is false', () => {
@@ -48,13 +49,13 @@ describe('AudioSettingsDrawer', () => {
   it('toggling a checkbox updates localStorage', async () => {
     const user = userEvent.setup();
     render(<AudioSettingsDrawer {...defaultProps} />);
-    const soundCheckbox = screen.getByRole('checkbox', { name: 'Sound' });
+    const soundEffectsCheckbox = screen.getByRole('checkbox', { name: 'Sound effects' });
 
     // Default is checked (localStorage has no 'false' value)
-    expect(soundCheckbox).toBeChecked();
+    expect(soundEffectsCheckbox).toBeChecked();
 
-    await user.click(soundCheckbox);
-    expect(localStorage.getItem('useSound')).toBe('false');
+    await user.click(soundEffectsCheckbox);
+    expect(localStorage.getItem('useSoundEffects')).toBe('false');
   });
 
   it('enforces mutual exclusivity between English speech recognition and flashcards', async () => {
@@ -76,6 +77,6 @@ describe('AudioSettingsDrawer', () => {
 
   it('does not render checkboxes when closed', () => {
     render(<AudioSettingsDrawer {...defaultProps} open={false} />);
-    expect(screen.queryByText('Sound')).not.toBeInTheDocument();
+    expect(screen.queryByText('Text-to-speech')).not.toBeInTheDocument();
   });
 });

--- a/web-client/src/components/Test/constants.ts
+++ b/web-client/src/components/Test/constants.ts
@@ -68,6 +68,7 @@ export const createInitialState = (props: Props): TestState => {
     drawnCharacters: [],
     numSpeakTries: 0,
     useSound: true,
+    useSoundEffects: true,
     useHandwriting: true,
     useChineseSpeechRecognition: true,
     useEnglishSpeechRecognition: true,

--- a/web-client/src/components/Test/types.ts
+++ b/web-client/src/components/Test/types.ts
@@ -27,6 +27,7 @@ export interface TestState {
   drawnCharacters: string[];
   numSpeakTries: number;
   useSound: boolean;
+  useSoundEffects: boolean;
   useHandwriting: boolean;
   useChineseSpeechRecognition: boolean;
   useEnglishSpeechRecognition: boolean;

--- a/web-client/src/components/Test/useTestEngine.ts
+++ b/web-client/src/components/Test/useTestEngine.ts
@@ -279,7 +279,7 @@ export const useTestEngine = (props: Props) => {
         idkDisabled: true,
         submitDisabled: true,
       });
-      if (current.useSound) {
+      if (current.useSoundEffects) {
         beep.play();
       }
       const permIndex = current.permList.indexOf(current.perm!);
@@ -349,7 +349,7 @@ export const useTestEngine = (props: Props) => {
     if (checkAnswer(current.answerInput)) {
       onCorrectAnswer();
     } else {
-      if (current.useSound) {
+      if (current.useSoundEffects) {
         fail.play();
       }
       let resultString = 'Try again';
@@ -418,7 +418,7 @@ export const useTestEngine = (props: Props) => {
         typeof current.answer === 'string' &&
         submission.replace(/[0-9]/g, '') === current.answer.replace(/[0-9]/g, '')
       ) {
-        if (current.useSound) {
+        if (current.useSoundEffects) {
           fail.play();
         }
         let sentence = 'Try different tones...';
@@ -441,7 +441,7 @@ export const useTestEngine = (props: Props) => {
           setTimeout(() => onListenRef.current(), 1500);
         }
       } else {
-        if (current.useSound) {
+        if (current.useSoundEffects) {
           fail.play();
         }
         if (current.numSpeakTries > 0) {
@@ -805,6 +805,8 @@ export const useTestEngine = (props: Props) => {
     const useSound =
       props.synthAvailable &&
       (!(localStorage.getItem('useSound') === 'false') || Boolean(props.isDemo));
+    const useSoundEffects =
+      !(localStorage.getItem('useSoundEffects') === 'false') || Boolean(props.isDemo);
     const useHandwriting =
       !(localStorage.getItem('useHandwriting') === 'false') || Boolean(props.isDemo);
     const useChineseSpeechRecognition =
@@ -819,6 +821,7 @@ export const useTestEngine = (props: Props) => {
 
     setStateMerged({
       useSound,
+      useSoundEffects,
       useHandwriting,
       useChineseSpeechRecognition,
       useEnglishSpeechRecognition,
@@ -905,7 +908,7 @@ export const useTestEngine = (props: Props) => {
 
       if (event.key === 'ArrowDown') {
         if (current.showAnswer && !current.idkDisabled) {
-          if (current.useSound) {
+          if (current.useSoundEffects) {
             fail.play();
           }
           setStateMerged({ noClicked: true });
@@ -1034,6 +1037,7 @@ export const useTestEngine = (props: Props) => {
     (updated: AudioSettings): void => {
       setStateMerged({
         useSound: updated.useSound && Boolean(props.synthAvailable),
+        useSoundEffects: updated.useSoundEffects,
         useChineseSpeechRecognition:
           updated.useChineseSpeechRecognition && Boolean(props.speechAvailable),
         useEnglishSpeechRecognition:

--- a/web-client/src/utils/audioSettings.test.ts
+++ b/web-client/src/utils/audioSettings.test.ts
@@ -11,6 +11,7 @@ describe('audioSettings', () => {
       const settings = getAudioSettings();
       expect(settings).toEqual({
         useSound: true,
+        useSoundEffects: true,
         useChineseSpeechRecognition: true,
         useEnglishSpeechRecognition: true,
         useAutoRecord: true,
@@ -67,9 +68,9 @@ describe('audioSettings', () => {
   });
 
   describe('getAudioSettingItems', () => {
-    it('returns 5 items', () => {
+    it('returns 6 items', () => {
       const items = getAudioSettingItems(true, true);
-      expect(items).toHaveLength(5);
+      expect(items).toHaveLength(6);
     });
 
     it('disables sound when synthAvailable is false', () => {

--- a/web-client/src/utils/audioSettings.ts
+++ b/web-client/src/utils/audioSettings.ts
@@ -1,5 +1,6 @@
 export interface AudioSettings {
   useSound: boolean;
+  useSoundEffects: boolean;
   useChineseSpeechRecognition: boolean;
   useEnglishSpeechRecognition: boolean;
   useAutoRecord: boolean;
@@ -8,6 +9,7 @@ export interface AudioSettings {
 
 export const getAudioSettings = (): AudioSettings => ({
   useSound: localStorage.getItem('useSound') !== 'false',
+  useSoundEffects: localStorage.getItem('useSoundEffects') !== 'false',
   useChineseSpeechRecognition: localStorage.getItem('useChineseSpeechRecognition') !== 'false',
   useEnglishSpeechRecognition: localStorage.getItem('useEnglishSpeechRecognition') !== 'false',
   useAutoRecord: localStorage.getItem('useAutoRecord') !== 'false',
@@ -39,8 +41,13 @@ export const getAudioSettingItems = (
 ): AudioSettingItem[] => [
   {
     key: 'useSound',
-    label: 'Sound',
+    label: 'Text-to-speech',
     disabled: !synthAvailable,
+  },
+  {
+    key: 'useSoundEffects',
+    label: 'Sound effects',
+    disabled: false,
   },
   {
     key: 'useChineseSpeechRecognition',


### PR DESCRIPTION
## Summary

Separates the "Sound" setting into two independent controls: **Text-to-speech** (TTS pronunciation playback) and **Sound effects** (correct/incorrect answer chimes). Previously, a single toggle controlled both, meaning users couldn't mute the beep/fail sounds without also losing TTS. The new "Sound effects" toggle can be changed mid-test via the AudioSettingsDrawer.

Closes #159

## Key implementation details

- Added `useSoundEffects` as a new boolean to `AudioSettings`, `TestState`, and the initial state
- `useSound` continues to control TTS behavior (auto-speak, speaker button, hint sentences) — renamed its label from "Sound" to "Text-to-speech" for clarity
- `useSoundEffects` controls the Howler.js `beep.play()` / `fail.play()` calls on correct/incorrect answers
- Sound effects are not gated by `synthAvailable` since they use Howler.js (pre-loaded WAV files), not the Web Speech API
- The setting is available in the mid-test `AudioSettingsDrawer`, satisfying the requirement to toggle sound effects during a test

## Decisions and trade-offs

- Kept `useSound` as the key for TTS rather than renaming to `useTTS` to avoid a breaking migration for existing users' localStorage values
- Sound effects default to `true` (enabled) for new users, matching the previous behavior
- No mutual exclusivity rules needed between the two sound settings — they are fully independent

## Files modified

- `web-client/src/utils/audioSettings.ts` — Added `useSoundEffects` to interface, getter, and setting items list
- `web-client/src/components/Test/types.ts` — Added `useSoundEffects` to `TestState`
- `web-client/src/components/Test/constants.ts` — Added `useSoundEffects: true` to initial state
- `web-client/src/components/Test/useTestEngine.ts` — Changed sound effect conditionals from `useSound` to `useSoundEffects`; added `useSoundEffects` to `initialiseSettings` and `refreshSettings`
- `web-client/src/components/Settings/Settings.tsx` — Added `useSoundEffects` checkbox, renamed "Sound" to "Text-to-speech"
- `web-client/src/utils/audioSettings.test.ts` — Updated default values assertion and item count
- `web-client/src/components/Settings/Settings.test.tsx` — Updated checkbox label references
- `web-client/src/components/Test/AudioSettingsDrawer/AudioSettingsDrawer.test.tsx` — Updated label references and assertions

---
Closes #159