### PR TITLE
[Feature Proposal] Amber warning color for 'Incorrect tones' feedback in vocab test

### DIFF
--- a/web-client/src/components/Test/Test.tsx
+++ b/web-client/src/components/Test/Test.tsx
@@ -163,11 +163,12 @@ const Test: React.FC<Props> = (props) => {
               color:
                 state.result === 'Correct' || state.result === 'Finished!'
                   ? 'success.main'
-                  : (state.result.startsWith('Answer was') && !state.showAnswer) ||
-                      state.result.startsWith('Try') ||
-                      state.result === 'Incorrect tones'
-                    ? 'error.main'
-                    : 'text.primary',
+                  : state.result === 'Incorrect tones'
+                    ? 'warning.main'
+                    : (state.result.startsWith('Answer was') && !state.showAnswer) ||
+                        state.result.startsWith('Try')
+                      ? 'error.main'
+                      : 'text.primary',
             }}
           >
             {state.result}


### PR DESCRIPTION
## Summary

Changes the "Incorrect tones" feedback color in the vocabulary test from red (`error.main`) to amber (`warning.main`), giving learners a visual signal that they were close — right syllables, wrong tones — rather than treating tone errors identically to fully wrong answers.

Closes #158

## What changed

In `web-client/src/components/Test/Test.tsx`, the `color` conditional on the result `Typography` was updated:

- **Before**: `'Incorrect tones'` was grouped with `'Try again'` and `'Answer was...'` under `error.main` (red)
- **After**: `'Incorrect tones'` gets its own branch mapped to `warning.main` (amber), while `'Try again'` and `'Answer was...'` remain `error.main`

## Key details

- Single-file, single-conditional change — no new state, components, or services
- The `toneChecker` logic in `useTestEngine.ts` already detects and sets the `'Incorrect tones'` result string; this PR only changes how that result is styled
- MUI's `warning.main` is amber/orange by default, providing clear visual differentiation from both success (green) and error (red)

## Files modified

- `web-client/src/components/Test/Test.tsx` — updated color conditional for result Typography

## Testing

All 782 existing tests pass. The existing `useTestEngine` test for "Incorrect tones" verifies the result string is set correctly; the color mapping is a presentation concern handled by the MUI theme.

---
Closes #158