### PR TITLE
[Tech Debt] Duplicate Chengyu interface with divergent shapes

### DIFF
--- a/web-client/src/data/chengyus.ts
+++ b/web-client/src/data/chengyus.ts
@@ -1,10 +1,4 @@
-export interface Chengyu {
-  characters: string;
-  // Traditional character equivalent. Must be provided for every entry.
-  trad: string;
-  pinyin: string;
-  meaning: string;
-}
+import { Chengyu } from '../types/models';
 
 export const chengyus: Chengyu[] = [
   {

--- a/web-client/src/types/models.ts
+++ b/web-client/src/types/models.ts
@@ -45,6 +45,8 @@ export interface TestPerm {
 
 export interface Chengyu {
   characters: string;
+  // Traditional character equivalent. Must be provided for every entry.
+  trad: string;
   pinyin: string;
   meaning: string;
   story?: string;


### PR DESCRIPTION
## Summary

Consolidates the duplicate `Chengyu` interface into a single canonical definition in `types/models.ts`.

- Added the missing `trad` (traditional characters) field to the `Chengyu` interface in `types/models.ts`
- Removed the duplicate interface definition from `data/chengyus.ts`
- Updated `data/chengyus.ts` to import `Chengyu` from `types/models.ts`

## Key details

The two interfaces had divergent shapes:
- `types/models.ts`: `{ characters, pinyin, meaning, story? }` — missing `trad`
- `data/chengyus.ts`: `{ characters, trad, pinyin, meaning }` — missing `story?`

The merged interface in `types/models.ts` now has all fields: `characters`, `trad`, `pinyin`, `meaning`, and `story?`.

No consumers needed updating because no code was importing the `Chengyu` type from `data/chengyus.ts` — the type was only used locally within that file for the `chengyus` array.

## Test plan

- [x] All 911 existing tests pass with no changes needed

## Files modified

- `web-client/src/types/models.ts` — added `trad: string` field to `Chengyu` interface
- `web-client/src/data/chengyus.ts` — removed duplicate interface, added import from `types/models`

Closes #176

---
Closes #176