### PR TITLE
Remove fixed height scroll for AddWords

### DIFF
--- a/web-client/src/containers/AddWords/AddWords.tsx
+++ b/web-client/src/containers/AddWords/AddWords.tsx
@@ -12,7 +12,6 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
-import Paper from '@mui/material/Paper';
 import WordCard from '../../components/AddWords/WordCard';
 
 import Modal from '../../components/UI/Modal/Modal';
@@ -419,20 +418,15 @@ const AddWords: React.FC<Props> = ({
 
   if (words) {
     table = (
-      <Paper
-        elevation={2}
+      <Box
         sx={{
           width: '100%',
           maxWidth: 700,
           mx: 'auto',
-          borderRadius: 2,
-          maxHeight: { xs: 220, sm: 250 },
-          overflowY: 'auto',
-          '@media (min-height: 750px)': { maxHeight: 400 },
         }}
       >
         {wordCards}
-      </Paper>
+      </Box>
     );
   }
 
@@ -533,11 +527,35 @@ const AddWords: React.FC<Props> = ({
       )}
       {words.length > 0 ? (
         <>
-          <Box sx={{ mb: 4, '& h3': { color: 'text.primary' } }}>{table}</Box>
-          <Button clicked={onTestHandler}>Test</Button>
-          <Button type="ghost" clicked={toggleWords}>
-            {buttonText}
-          </Button>
+          <Box sx={{ mb: 0, '& h3': { color: 'text.primary' } }}>{table}</Box>
+          <Box
+            sx={(theme) => ({
+              position: 'sticky',
+              bottom: 0,
+              zIndex: 10,
+              pt: 1,
+              pb: 2,
+              display: 'flex',
+              justifyContent: 'center',
+              gap: 1,
+              backgroundColor: theme.palette.background.default,
+              '&::before': {
+                content: '""',
+                position: 'absolute',
+                top: -24,
+                left: 0,
+                right: 0,
+                height: 24,
+                background: `linear-gradient(to bottom, transparent, ${theme.palette.background.default})`,
+                pointerEvents: 'none',
+              },
+            })}
+          >
+            <Button clicked={onTestHandler}>Test</Button>
+            <Button type="ghost" clicked={toggleWords}>
+              {buttonText}
+            </Button>
+          </Box>
         </>
       ) : (
         <Typography


### PR DESCRIPTION
## Summary

Removes the fixed-height scrollable container from the AddWords word list and renders word cards directly on the page. The page itself becomes scrollable when there are many words, providing a more natural mobile browsing experience.

The Test and Hide Table buttons now use `position: sticky` at the bottom of the viewport so they remain accessible even when the word list is long. A gradient fade above the buttons visually indicates that more content can be reached by scrolling.

## Key implementation details

- **Removed**: `Paper` component with `maxHeight` (220–400px) and `overflowY: auto` that created the nested scroll area
- **Added**: Sticky button bar (`position: sticky; bottom: 0`) with `backgroundColor` matching the page background so buttons float cleanly over word cards
- **Added**: CSS `::before` pseudo-element on the button bar creating a 24px gradient fade from transparent to the background color, hinting at scrollable content beneath
- **Theme-aware**: Uses MUI's `theme.palette.background.default` via the `sx` callback for both the button background and fade gradient, so it works correctly with any theme

## Decisions and trade-offs

- Used `position: sticky` rather than `position: fixed` — sticky naturally becomes inline when the content is short enough that buttons aren't pushed off-screen, matching the issue requirement exactly
- Removed the `Paper` elevation wrapper entirely since word cards already have their own visual styling
- Kept the existing show/hide toggle behavior unchanged

## Files modified

- `web-client/src/containers/AddWords/AddWords.tsx` — removed fixed-height Paper scroll container, added sticky button bar with fade gradient

Closes #211

---
Closes #211