### PR TITLE
Add to Chengyu to words button should match theme

### DIFF
--- a/web-client/e2e/chengyu.spec.ts
+++ b/web-client/e2e/chengyu.spec.ts
@@ -109,4 +109,31 @@ test.describe('Chengyu daily challenge', () => {
     // Button should change to "Saved!"
     await expect(page.getByRole('button', { name: /Saved!/i })).toBeVisible({ timeout: 5000 });
   });
+
+  test('save button uses primary theme styling (dark green background, white text)', async ({
+    page,
+  }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.navigateTo();
+
+    await expect(page.getByText('Chengyu Of The Day')).toBeVisible({ timeout: 10000 });
+
+    // Solve the chengyu
+    await dashboard.solveChengyu();
+
+    // Should see "Save to my words" button after solving
+    const saveButton = page.getByRole('button', { name: /Save to my words/i });
+    await expect(saveButton).toBeVisible({ timeout: 5000 });
+
+    // Verify the button has dark green background (#1a5c40) and white text
+    const bgColor = await saveButton.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    const textColor = await saveButton.evaluate((el) => getComputedStyle(el).color);
+
+    // #1a5c40 = rgb(26, 92, 64)
+    expect(bgColor).toBe('rgb(26, 92, 64)');
+    // White text
+    expect(textColor).toBe('rgb(255, 255, 255)');
+  });
 });

--- a/web-client/src/components/Home/Chengyu/Chengyu.tsx
+++ b/web-client/src/components/Home/Chengyu/Chengyu.tsx
@@ -3,13 +3,13 @@ import { connect, ConnectedProps } from 'react-redux';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 
 import { getDailyChengyu, convertDailyChengyu } from '../../../data/chengyus';
+import Button from '../../UI/Buttons/Button/Button';
 import { RootState } from '../../../types/store';
 import { Word } from '../../../types/models';
 import { postWord } from '../../../store/actions/word';
@@ -184,11 +184,10 @@ const Chengyu: React.FC<PropsFromRedux> = ({ userId, words, onSaveWord }) => {
   const saveButton =
     finished && userId ? (
       <Button
-        variant="contained"
-        color="primary"
-        onClick={handleSave}
+        type="primary"
+        clicked={handleSave}
         disabled={alreadySaved || saved}
-        sx={{ mt: 2 }}
+        style={{ marginTop: 16 }}
       >
         {saved ? 'Saved!' : alreadySaved ? 'Already saved' : 'Save to my words'}
       </Button>


### PR DESCRIPTION
## Summary

The "Save to my words" button shown after solving the daily chengyu challenge was using MUI's default `Button` with `color="primary"`, which rendered with the beige theme color instead of the dark green primary button style used throughout the rest of the app.

This PR replaces the MUI `Button` with the project's custom `Button` component (`components/UI/Buttons/Button/Button.tsx`), which applies the correct primary styling: dark green background (`#1a5c40`) with white text.

## Key implementation details

- Swapped the import from `@mui/material/Button` to the custom `Button` component
- Updated props to match the custom Button's API: `clicked` instead of `onClick`, `type="primary"` instead of `variant`/`color`, and `style` instead of `sx`
- Added an E2E test that verifies the button's computed `backgroundColor` and `color` match the expected theme values

## Files modified

- `web-client/src/components/Home/Chengyu/Chengyu.tsx` — replaced MUI Button with custom themed Button
- `web-client/e2e/chengyu.spec.ts` — added E2E test for button styling verification

---
Closes #228