### PR TITLE
Make traditional the default character set

### DIFF
--- a/web-client/e2e/default-charset.spec.ts
+++ b/web-client/e2e/default-charset.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import {
+  clearEmulatorData,
+  seedTestUser,
+  seedWords,
+  loginViaUI,
+  TEST_USER,
+  TEST_WORDS,
+} from './fixtures/seed';
+
+test.describe('Default character set is Traditional', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearEmulatorData();
+    await seedTestUser();
+  });
+
+  test('Settings page shows Traditional as the default character set', async ({ page }) => {
+    // Do NOT call configureTestSettings — we want pristine localStorage
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    const tradRadio = page.getByRole('radio', { name: 'Traditional' });
+    await expect(tradRadio).toBeChecked();
+
+    const simpRadio = page.getByRole('radio', { name: 'Simplified' });
+    await expect(simpRadio).not.toBeChecked();
+  });
+
+  test('word list displays traditional characters by default', async ({ page }) => {
+    // Seed words that have different simp/trad forms
+    await seedWords(TEST_USER.uid, TEST_WORDS);
+
+    // Login without configureTestSettings to keep default charSet
+    await loginViaUI(page);
+    await page.goto('/add-words');
+
+    // TEST_WORDS[1] is 谢谢/謝謝 — these differ between simp and trad
+    // With trad as default, we should see the traditional form
+    await expect(page.getByText('謝謝').first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('user can switch to Simplified in settings and it persists', async ({ page }) => {
+    await seedWords(TEST_USER.uid, TEST_WORDS);
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    // Switch to Simplified
+    const simpRadio = page.getByRole('radio', { name: 'Simplified' });
+    await simpRadio.click();
+    await expect(simpRadio).toBeChecked();
+
+    // Navigate to add-words to verify simplified characters are shown
+    await page.goto('/add-words');
+    await expect(page.getByText('谢谢').first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/web-client/src/components/Home/Chengyu/Chengyu.test.tsx
+++ b/web-client/src/components/Home/Chengyu/Chengyu.test.tsx
@@ -105,7 +105,7 @@ describe('Chengyu — initial render', () => {
 
   it('displays the chengyu characters', () => {
     renderWithProviders(<Chengyu />, { store: makeStore() });
-    expect(screen.getByText('独一无二')).toBeInTheDocument();
+    expect(screen.getByText('獨一無二')).toBeInTheDocument();
   });
 
   it('renders all four answer options', () => {
@@ -163,7 +163,7 @@ describe('Chengyu — answering correctly', () => {
     await user.click(screen.getByRole('button', { name: /^unique$/ }));
 
     await waitFor(() => {
-      expect(screen.getByText('独')).toBeInTheDocument();
+      expect(screen.getByText('獨')).toBeInTheDocument();
       expect(screen.getByText('一')).toBeInTheDocument();
     });
   });
@@ -316,7 +316,7 @@ describe('Chengyu — example sentence after completion', () => {
     await user.click(screen.getByRole('button', { name: /^unique$/ }));
 
     await waitFor(() => {
-      expect(getChengyuExampleSentence).toHaveBeenCalledWith('独一无二', 'simp');
+      expect(getChengyuExampleSentence).toHaveBeenCalledWith('独一无二', 'trad');
     });
   });
 });

--- a/web-client/src/components/Home/Chengyu/Chengyu.tsx
+++ b/web-client/src/components/Home/Chengyu/Chengyu.tsx
@@ -51,7 +51,7 @@ const Chengyu: React.FC<PropsFromRedux> = ({ userId, words, onSaveWord }) => {
   const [exampleSentence, setExampleSentence] = useState<ChengyuSentence | null>(null);
   const [sentenceLoading, setSentenceLoading] = useState(false);
   const [charSet] = useState<'simp' | 'trad'>(
-    (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp',
+    (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad',
   );
 
   const dailyChengyu = useMemo(() => getDailyChengyu(), []);

--- a/web-client/src/components/Settings/Settings.test.tsx
+++ b/web-client/src/components/Settings/Settings.test.tsx
@@ -52,10 +52,10 @@ describe('Settings — accessibility', () => {
 });
 
 describe('Settings — initial render from localStorage', () => {
-  it('defaults charSet to Simplified when localStorage is empty', () => {
+  it('defaults charSet to Traditional when localStorage is empty', () => {
     renderWithProviders(<Settings />, { store: makeStore() });
-    const simpRadio = screen.getByRole('radio', { name: /simplified/i });
-    expect(simpRadio).toBeChecked();
+    const tradRadio = screen.getByRole('radio', { name: /traditional/i });
+    expect(tradRadio).toBeChecked();
   });
 
   it('reads charSet = trad from localStorage', () => {
@@ -79,20 +79,8 @@ describe('Settings — initial render from localStorage', () => {
 });
 
 describe('Settings — character set radio buttons', () => {
-  it('switches to Traditional when Traditional radio is clicked', async () => {
+  it('switches to Simplified when Simplified radio is clicked', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<Settings />, { store: makeStore() });
-
-    const tradRadio = screen.getByRole('radio', { name: /traditional/i });
-    await user.click(tradRadio);
-
-    expect(tradRadio).toBeChecked();
-    expect(localStorage.getItem('charSet')).toBe('trad');
-  });
-
-  it('switches back to Simplified when Simplified radio is clicked', async () => {
-    const user = userEvent.setup();
-    localStorage.setItem('charSet', 'trad');
     renderWithProviders(<Settings />, { store: makeStore() });
 
     const simpRadio = screen.getByRole('radio', { name: /simplified/i });
@@ -100,6 +88,18 @@ describe('Settings — character set radio buttons', () => {
 
     expect(simpRadio).toBeChecked();
     expect(localStorage.getItem('charSet')).toBe('simp');
+  });
+
+  it('switches back to Traditional when Traditional radio is clicked', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('charSet', 'simp');
+    renderWithProviders(<Settings />, { store: makeStore() });
+
+    const tradRadio = screen.getByRole('radio', { name: /traditional/i });
+    await user.click(tradRadio);
+
+    expect(tradRadio).toBeChecked();
+    expect(localStorage.getItem('charSet')).toBe('trad');
   });
 });
 

--- a/web-client/src/components/Settings/Settings.tsx
+++ b/web-client/src/components/Settings/Settings.tsx
@@ -95,7 +95,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
     const onlyPriority = localStorage.getItem('onlyPriority');
 
     return {
-      charSet: localCharSet || 'simp',
+      charSet: localCharSet || 'trad',
       numWords: localNumWords ? parseInt(localNumWords) : 5,
       useChineseSpeechRecognition: useChineseSpeechRecognition === 'false' ? false : true,
       useEnglishSpeechRecognition: useEnglishSpeechRecognition === 'false' ? false : true,

--- a/web-client/src/components/Test/NewWords/NewWord/NewWord.tsx
+++ b/web-client/src/components/Test/NewWords/NewWord/NewWord.tsx
@@ -60,7 +60,7 @@ const NewWord: React.FC<Props> = ({
   const charCache = useRef<Map<string, CharData>>(new Map());
   const [editedMeaning, setEditedMeaning] = useState(word.meaning);
   const [charSet] = useState<'simp' | 'trad'>(
-    (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp',
+    (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad',
   );
   const [useSound] = useState(
     localStorage.getItem('useSound') === 'false' || !synthAvailable ? false : true,
@@ -93,7 +93,7 @@ const NewWord: React.FC<Props> = ({
 
   const onDisplayMeaning = useCallback(async (char: string): Promise<void> => {
     try {
-      const charSet = (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp';
+      const charSet = (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad';
       const results = await searchWord(char, charSet);
       let data: CharData;
       if (results.length > 0) {

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
@@ -689,7 +689,7 @@ describe('SentenceRead — decomposed array word rendering', () => {
 
     await waitFor(() => {
       // Both sub-words should be rendered as popup spans
-      expect(screen.getByLabelText(/学.*tap to see meaning/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/學.*tap to see meaning/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/生.*tap to see meaning/i)).toBeInTheDocument();
     });
   });

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
@@ -151,7 +151,7 @@ const SentenceRead: React.FC<Props> = ({
   const [state, setState] = useState<SentenceReadState>({
     sentences: [],
     totalCount: 0,
-    charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp',
+    charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad',
     sentenceIndex: 0,
     wordIndex: 0,
     submitted: false,

--- a/web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx
+++ b/web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx
@@ -265,9 +265,9 @@ describe('SentenceWrite — translation feature', () => {
     await user.click(screen.getByText('student.'));
     await user.click(screen.getByRole('button', { name: /translate/i }));
 
-    // Should show the Chinese translation
+    // Should show the Chinese translation (trad is default charSet)
     await waitFor(() => {
-      expect(screen.getByText('学生')).toBeInTheDocument();
+      expect(screen.getByText('學生')).toBeInTheDocument();
       expect(screen.getByText('xué shēng')).toBeInTheDocument();
     });
   });

--- a/web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx
+++ b/web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx
@@ -113,7 +113,7 @@ const SentenceWrite: React.FC<Props> = ({
 }) => {
   const [state, setState] = useState<SentenceWriteState>(() => ({
     wordIndex: 0,
-    charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp',
+    charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad',
     useChineseSpeechRecognition:
       (localStorage.getItem('useChineseSpeechRecognition') !== 'false' || Boolean(isDemo)) &&
       speechAvailable,

--- a/web-client/src/components/Test/constants.test.ts
+++ b/web-client/src/components/Test/constants.test.ts
@@ -39,7 +39,7 @@ describe('createInitialState', () => {
     const state = createInitialState(makeProps());
 
     expect(state.numWords).toBe(5);
-    expect(state.charSet).toBe('simp');
+    expect(state.charSet).toBe('trad');
     expect(state.priority).toBe('none');
     expect(state.onlyPriority).toBe(false);
     expect(state.testFinished).toBe(false);
@@ -88,20 +88,20 @@ describe('createInitialState', () => {
     expect(state.testFinished).toBe(true);
   });
 
-  it('uses simp characters by default for devTestFinished scoreList', () => {
-    const state = createInitialState(makeProps({ devTestFinished: true }));
-
-    expect(state.scoreList[0].char).toBe('你好');
-    expect(state.scoreList[1].char).toBe('谢谢');
-  });
-
-  it('uses trad characters when charSet is trad for devTestFinished scoreList', () => {
-    localStorage.setItem('charSet', 'trad');
-
+  it('uses trad characters by default for devTestFinished scoreList', () => {
     const state = createInitialState(makeProps({ devTestFinished: true }));
 
     expect(state.scoreList[0].char).toBe('你好');
     expect(state.scoreList[1].char).toBe('謝謝');
+  });
+
+  it('uses simp characters when charSet is simp for devTestFinished scoreList', () => {
+    localStorage.setItem('charSet', 'simp');
+
+    const state = createInitialState(makeProps({ devTestFinished: true }));
+
+    expect(state.scoreList[0].char).toBe('你好');
+    expect(state.scoreList[1].char).toBe('谢谢');
   });
 
   it('initializes all UI state fields to their defaults', () => {

--- a/web-client/src/components/Test/constants.ts
+++ b/web-client/src/components/Test/constants.ts
@@ -30,7 +30,7 @@ export const activeButtonStyle = {
 
 export const createInitialState = (props: Props): TestState => {
   const numWords = parseInt(localStorage.getItem('numWords') || '5');
-  const charSet = (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp';
+  const charSet = (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad';
   const priority = props.isDemo ? 'none' : localStorage.getItem('priority') || 'none';
   const onlyPriority = props.isDemo ? false : localStorage.getItem('onlyPriority') === 'true';
 

--- a/web-client/src/components/TestChengyusTest/TestChengyusTest.tsx
+++ b/web-client/src/components/TestChengyusTest/TestChengyusTest.tsx
@@ -54,7 +54,7 @@ const TestChengyusTest: React.FC<Props> = ({
 }) => {
   const [state, setState] = useState<TestChengyusTestState>(() => ({
     wordIndex: 0,
-    charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp',
+    charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad',
     charData: null,
     errorMessage: '',
     showChengyuMeaning: false,

--- a/web-client/src/containers/AddWords/AddWords.test.tsx
+++ b/web-client/src/containers/AddWords/AddWords.test.tsx
@@ -80,7 +80,7 @@ describe('AddWords — word search and add flow', () => {
       },
     });
     renderWithProviders(<AddWords />, { store });
-    expect(screen.getByText('学习')).toBeInTheDocument();
+    expect(screen.getByText('學習')).toBeInTheDocument();
     expect(screen.getByText('xué xí')).toBeInTheDocument();
   });
 
@@ -387,7 +387,7 @@ describe('AddWords — toggle show/hide table', () => {
     renderWithProviders(<AddWords />, { store });
 
     // Initially the table should be visible
-    expect(screen.getByText('学习')).toBeInTheDocument();
+    expect(screen.getByText('學習')).toBeInTheDocument();
 
     // Click "Hide Table"
     const hideBtn = screen.getByRole('button', { name: /hide table/i });
@@ -505,7 +505,7 @@ describe('AddWords — pronunciation playback', () => {
     await userEvent.click(playButtons[0]);
 
     expect(ttsService.speak).toHaveBeenCalledWith(
-      '学习',
+      '學習',
       expect.objectContaining({ onEnd: expect.any(Function), onError: expect.any(Function) }),
     );
   });

--- a/web-client/src/containers/AddWords/AddWords.tsx
+++ b/web-client/src/containers/AddWords/AddWords.tsx
@@ -105,7 +105,7 @@ const AddWords: React.FC<Props> = ({
   isDemo,
 }) => {
   const [state, setState] = useState<AddWordsState>(() => {
-    const charSet = (localStorage.getItem('charSet') as 'simp' | 'trad') || 'simp';
+    const charSet = (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad';
     return {
       newWord: '',
       errorMessage: '',

--- a/web-client/src/services/wordService.test.ts
+++ b/web-client/src/services/wordService.test.ts
@@ -525,7 +525,7 @@ describe('addCustomWord', () => {
       .mockResolvedValueOnce({ pinyin: 'nǐ', trad: '你' })
       .mockResolvedValueOnce({ pinyin: 'hǎo', trad: '好' });
 
-    const word = await addCustomWord('user-1', '你好', 'hello');
+    const word = await addCustomWord('user-1', '你好', 'hello', 'simp');
 
     expect(word.simp).toBe('你好');
     expect(word.trad).toBe('你好');
@@ -549,7 +549,7 @@ describe('addCustomWord', () => {
   it('falls back to the raw char for simp/trad when lookupCharacter returns null', async () => {
     vi.mocked(lookupCharacter).mockResolvedValue(null);
 
-    const word = await addCustomWord('user-1', '好', 'good');
+    const word = await addCustomWord('user-1', '好', 'good', 'simp');
 
     expect(word.simp).toBe('好');
     expect(word.trad).toBe('好');
@@ -571,7 +571,7 @@ describe('addCustomWord', () => {
       .mockResolvedValueOnce({ pinyin: 'nǐ', trad: '你' })
       .mockResolvedValueOnce(null); // second char not found
 
-    const word = await addCustomWord('user-1', '你X', 'hello X');
+    const word = await addCustomWord('user-1', '你X', 'hello X', 'simp');
 
     expect(word.simp).toBe('你X');
     expect(word.trad).toBe('你X');
@@ -581,7 +581,7 @@ describe('addCustomWord', () => {
   it('returns a word with a negative id (avoids collision with dictionary IDs)', async () => {
     vi.mocked(lookupCharacter).mockResolvedValue(null);
 
-    const word = await addCustomWord('user-1', '好', 'good');
+    const word = await addCustomWord('user-1', '好', 'good', 'simp');
 
     expect(word.id).toBeLessThan(0);
   });
@@ -589,7 +589,7 @@ describe('addCustomWord', () => {
   it('calls setDoc (via addWordToList) with the constructed word data', async () => {
     vi.mocked(lookupCharacter).mockResolvedValue({ pinyin: 'shū', trad: '書' });
 
-    await addCustomWord('user-1', '书', 'book');
+    await addCustomWord('user-1', '书', 'book', 'simp');
 
     expect(mockSetDoc).toHaveBeenCalledOnce();
     const setDocArg = mockSetDoc.mock.calls[0][1];
@@ -602,7 +602,7 @@ describe('addCustomWord', () => {
     // lookupCharacter returns trad: undefined-ish — simulate with empty string fallback
     vi.mocked(lookupCharacter).mockResolvedValue({ pinyin: 'hǎo', trad: '' });
 
-    const word = await addCustomWord('user-1', '好', 'good');
+    const word = await addCustomWord('user-1', '好', 'good', 'simp');
 
     // trad falls back to the original char when trad is falsy
     expect(word.trad).toBe('好');

--- a/web-client/src/services/wordService.ts
+++ b/web-client/src/services/wordService.ts
@@ -338,7 +338,7 @@ export const addCustomWord = async (
   userId: string,
   text: string,
   meaning: string,
-  charSet: 'simp' | 'trad' = 'simp',
+  charSet: 'simp' | 'trad' = 'trad',
   listId: string = 'default',
 ): Promise<Word> => {
   const validatedText = customWordTextSchema.parse(text);


### PR DESCRIPTION
## Summary

Changes the default character set from Simplified (`'simp'`) to Traditional (`'trad'`) across the entire application. When a user has no `charSet` preference stored in localStorage (e.g., new users), the app now defaults to Traditional Chinese characters.

Closes #269

## Key implementation details

The `charSet` preference is stored in `localStorage` and read independently by each component that displays Chinese characters. Every location that falls back to a default value (`|| 'simp'`) was updated to `|| 'trad'`:

- **Settings.tsx** — initial state default
- **AddWords.tsx** — word list display and search
- **Test/constants.ts** — test session character set
- **NewWord.tsx** — new word display (2 occurrences)
- **SentenceRead.tsx** — sentence reading stage
- **SentenceWrite.tsx** — sentence writing stage
- **TestChengyusTest.tsx** — chengyu test display
- **Chengyu.tsx** — daily chengyu on home page
- **wordService.ts** — `addCustomWord()` default parameter

Existing users who have already set a preference in localStorage are unaffected — their stored value takes precedence.

## Test changes

- **Settings.test.tsx** — default expectation changed from Simplified to Traditional; radio toggle tests updated accordingly
- **constants.test.ts** — default charSet expectation changed; devTestFinished scoreList test updated to expect trad characters
- **SentenceWrite.test.tsx**, **SentenceRead.test.tsx** — assertions updated to expect traditional character forms
- **Chengyu.test.tsx** — display assertions updated to traditional characters
- **AddWords.test.tsx** — word display and TTS assertions updated to traditional characters
- **wordService.test.ts** — tests that relied on the implicit `'simp'` default now pass `'simp'` explicitly

All 1130 unit tests pass.

## E2E tests

Added `web-client/e2e/default-charset.spec.ts` with three tests:
1. Settings page shows Traditional radio as checked by default
2. Word list displays traditional characters (e.g., 謝謝 not 谢谢) by default
3. User can switch to Simplified in settings and see simplified characters on the word list

## Files modified

- `web-client/src/components/Settings/Settings.tsx`
- `web-client/src/components/Settings/Settings.test.tsx`
- `web-client/src/containers/AddWords/AddWords.tsx`
- `web-client/src/containers/AddWords/AddWords.test.tsx`
- `web-client/src/components/Test/constants.ts`
- `web-client/src/components/Test/constants.test.ts`
- `web-client/src/components/Test/NewWords/NewWord/NewWord.tsx`
- `web-client/src/components/Test/SentenceRead/SentenceRead.tsx`
- `web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx`
- `web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx`
- `web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx`
- `web-client/src/components/TestChengyusTest/TestChengyusTest.tsx`
- `web-client/src/components/Home/Chengyu/Chengyu.tsx`
- `web-client/src/components/Home/Chengyu/Chengyu.test.tsx`
- `web-client/src/services/wordService.ts`
- `web-client/src/services/wordService.test.ts`
- `web-client/e2e/default-charset.spec.ts` (new)

---
Closes #269