### PR TITLE
Add option to enable sentence stages for all words (#278)

### DIFF
--- a/web-client/e2e/sentence-stages-all-words.spec.ts
+++ b/web-client/e2e/sentence-stages-all-words.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { clearEmulatorData, seedTestUser, loginViaUI } from './fixtures/seed';
+
+test.describe('Sentence stages for all words setting', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearEmulatorData();
+    await seedTestUser();
+  });
+
+  test('Settings page shows the "Sentence stages for all words" checkbox unchecked by default', async ({
+    page,
+  }) => {
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    const checkbox = page.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).not.toBeChecked();
+  });
+
+  test('toggling the checkbox persists the setting to localStorage', async ({ page }) => {
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    const checkbox = page.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+
+    // Verify localStorage was updated
+    const storedValue = await page.evaluate(() =>
+      localStorage.getItem('sentenceStagesForAllWords'),
+    );
+    expect(storedValue).toBe('true');
+  });
+
+  test('setting persists after page reload', async ({ page }) => {
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    // Enable the setting
+    const checkbox = page.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+
+    // Reload the page
+    await page.reload();
+
+    // Verify the checkbox is still checked
+    const checkboxAfterReload = page.getByRole('checkbox', {
+      name: /sentence stages for all words/i,
+    });
+    await expect(checkboxAfterReload).toBeChecked();
+  });
+
+  test('checkbox is disabled when both sentence stages are turned off', async ({ page }) => {
+    // Set both sentence stages to false via localStorage before navigating
+    await page.addInitScript(() => {
+      localStorage.setItem('sentenceRead', 'false');
+      localStorage.setItem('sentenceWrite', 'false');
+    });
+
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    const checkbox = page.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await expect(checkbox).toBeDisabled();
+  });
+
+  test('estimated test time updates when the setting is toggled', async ({ page }) => {
+    // Set 10 words so the estimate difference is noticeable
+    await page.addInitScript(() => {
+      localStorage.setItem('numWords', '10');
+    });
+
+    await loginViaUI(page);
+    await page.goto('/settings');
+
+    const estimateEl = page.getByText(/estimated test time:/i);
+    const initialText = await estimateEl.textContent();
+
+    // Toggle the setting on
+    const checkbox = page.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await checkbox.click();
+
+    // The estimated time should change
+    await expect(estimateEl).not.toHaveText(initialText!);
+  });
+});

--- a/web-client/src/components/Settings/Settings.test.tsx
+++ b/web-client/src/components/Settings/Settings.test.tsx
@@ -279,6 +279,8 @@ describe('Settings — time estimate display', () => {
 
   it('updates estimate when stage checkbox is toggled off', async () => {
     const user = userEvent.setup();
+    // Use a larger numWords so the sentence stage time difference is noticeable
+    localStorage.setItem('numWords', '15');
     renderWithProviders(<Settings />, { store: makeStore() });
 
     const estimateEl = screen.getByText(/estimated test time:/i);
@@ -329,5 +331,69 @@ describe('Settings — Only Priority checkbox', () => {
     const onlyPriorityCheckbox = screen.getByRole('checkbox', { name: /only priority/i });
     await user.click(onlyPriorityCheckbox);
     expect(localStorage.getItem('onlyPriority')).toBe('true');
+  });
+});
+
+describe('Settings — sentence stages for all words', () => {
+  it('renders the "Sentence stages for all words" checkbox unchecked by default', () => {
+    renderWithProviders(<Settings />, { store: makeStore() });
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('reads sentenceStagesForAllWords=true from localStorage', () => {
+    localStorage.setItem('sentenceStagesForAllWords', 'true');
+    renderWithProviders(<Settings />, { store: makeStore() });
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('toggling the checkbox persists to localStorage', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Settings />, { store: makeStore() });
+
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await user.click(checkbox);
+    expect(localStorage.getItem('sentenceStagesForAllWords')).toBe('true');
+  });
+
+  it('is disabled when both sentence stages are off', () => {
+    localStorage.setItem('sentenceRead', 'false');
+    localStorage.setItem('sentenceWrite', 'false');
+    renderWithProviders(<Settings />, { store: makeStore() });
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('is enabled when sentenceRead is on', () => {
+    localStorage.setItem('sentenceRead', 'true');
+    localStorage.setItem('sentenceWrite', 'false');
+    renderWithProviders(<Settings />, { store: makeStore(true, false) });
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    expect(checkbox).not.toBeDisabled();
+  });
+
+  it('is enabled when sentenceWrite is on', () => {
+    localStorage.setItem('sentenceRead', 'false');
+    localStorage.setItem('sentenceWrite', 'true');
+    renderWithProviders(<Settings />, { store: makeStore() });
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    expect(checkbox).not.toBeDisabled();
+  });
+
+  it('updates the estimated test time when toggled on', async () => {
+    const user = userEvent.setup();
+    // Ensure sentence stages are enabled so the checkbox is active
+    localStorage.setItem('numWords', '10');
+    renderWithProviders(<Settings />, { store: makeStore() });
+
+    const estimateEl = screen.getByText(/estimated test time:/i);
+    const initialText = estimateEl.textContent;
+
+    const checkbox = screen.getByRole('checkbox', { name: /sentence stages for all words/i });
+    await user.click(checkbox);
+
+    expect(estimateEl.textContent).not.toBe(initialText);
   });
 });

--- a/web-client/src/components/Settings/Settings.tsx
+++ b/web-client/src/components/Settings/Settings.tsx
@@ -27,6 +27,7 @@ interface SettingsState {
   newWords: boolean;
   sentenceRead: boolean;
   sentenceWrite: boolean;
+  sentenceStagesForAllWords: boolean;
   priority: string;
   onlyPriority: boolean;
   [key: string]: string | number | boolean;
@@ -91,6 +92,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
     const newWords = localStorage.getItem('newWords');
     const sentenceRead = localStorage.getItem('sentenceRead');
     const sentenceWrite = localStorage.getItem('sentenceWrite');
+    const sentenceStagesForAllWords = localStorage.getItem('sentenceStagesForAllWords');
     const priority = localStorage.getItem('priority');
     const onlyPriority = localStorage.getItem('onlyPriority');
 
@@ -107,6 +109,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
       newWords: newWords === 'false' ? false : true,
       sentenceRead: sentenceRead === 'false' ? false : true,
       sentenceWrite: sentenceWrite === 'false' ? false : true,
+      sentenceStagesForAllWords: sentenceStagesForAllWords === 'true' ? true : false,
       priority: priority || 'none',
       onlyPriority: onlyPriority === 'true' ? true : false,
     };
@@ -266,6 +269,13 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
       disabled: false,
       disabledTooltip: '',
     },
+    {
+      value: 'sentenceStagesForAllWords',
+      label: 'Sentence stages for all words',
+      checked: state.sentenceStagesForAllWords && (state.sentenceRead || state.sentenceWrite),
+      disabled: !state.sentenceRead && !state.sentenceWrite,
+      disabledTooltip: 'Enable at least one sentence stage first',
+    },
   ];
 
   const timeEstimate = useMemo(
@@ -279,6 +289,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
           newWordsEnabled: state.newWords,
           sentenceReadEnabled: state.sentenceRead,
           sentenceWriteEnabled: state.sentenceWrite,
+          sentenceStagesForAllWords: state.sentenceStagesForAllWords,
         }),
       ),
     [
@@ -289,6 +300,7 @@ const Settings: React.FC<PropsFromRedux> = ({ speechAvailable, synthAvailable })
       state.newWords,
       state.sentenceRead,
       state.sentenceWrite,
+      state.sentenceStagesForAllWords,
     ],
   );
 

--- a/web-client/src/components/Test/types.ts
+++ b/web-client/src/components/Test/types.ts
@@ -75,6 +75,7 @@ export interface OwnProps {
   onVocabComplete?: (scores: WordScore[]) => void;
   devTestFinished?: boolean;
   practiceMode?: boolean;
+  sentenceStagesForAllWords?: boolean;
 }
 
 export type Props = ReduxProps & OwnProps & RouteComponentProps;

--- a/web-client/src/components/Test/useTestEngine.ts
+++ b/web-client/src/components/Test/useTestEngine.ts
@@ -191,7 +191,10 @@ export const useTestEngine = (props: Props) => {
         count = 4;
       }
 
-      if (count === 0 && (word.level === 1 || props.practiceMode)) {
+      if (
+        count === 0 &&
+        (word.level === 1 || props.practiceMode || props.sentenceStagesForAllWords)
+      ) {
         sentenceWords.push(word);
       }
 

--- a/web-client/src/containers/TestWords/TestWords.stages.test.tsx
+++ b/web-client/src/containers/TestWords/TestWords.stages.test.tsx
@@ -331,3 +331,30 @@ describe('TestWords — practiceMode prop', () => {
     });
   });
 });
+
+describe('TestWords — sentenceStagesForAllWords prop', () => {
+  it('passes sentenceStagesForAllWords=false by default', async () => {
+    const store = makeStore({ words: [dueWord(1, '你好', 2)] });
+    renderWithProviders(<TestWords />, { store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test')).toBeInTheDocument();
+      expect(capturedTestProps.sentenceStagesForAllWords).toBe(false);
+    });
+  });
+
+  it('passes sentenceStagesForAllWords=true when localStorage setting is enabled', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => {
+      if (key === 'sentenceStagesForAllWords') return 'true';
+      return null;
+    });
+
+    const store = makeStore({ words: [dueWord(1, '你好', 2)] });
+    renderWithProviders(<TestWords />, { store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test')).toBeInTheDocument();
+      expect(capturedTestProps.sentenceStagesForAllWords).toBe(true);
+    });
+  });
+});

--- a/web-client/src/containers/TestWords/TestWords.tsx
+++ b/web-client/src/containers/TestWords/TestWords.tsx
@@ -34,6 +34,7 @@ interface TestWordsState {
   newWordsEnabled: boolean;
   sentenceReadEnabled: boolean;
   sentenceWriteEnabled: boolean;
+  sentenceStagesForAllWords: boolean;
   devTestFinished: boolean; // For testing TestSummary directly
   practiceMode: boolean; // Practice mode ignores due dates and doesn't update them
   wordsInitialized: boolean; // True once word selection has run (prevents flash of "No words due")
@@ -94,6 +95,9 @@ const TestWords: React.FC<Props> = ({
     newWordsEnabled: isDemo ? true : localStorage.getItem('newWords') !== 'false',
     sentenceReadEnabled: isDemo ? true : localStorage.getItem('sentenceRead') !== 'false',
     sentenceWriteEnabled: isDemo ? true : localStorage.getItem('sentenceWrite') !== 'false',
+    sentenceStagesForAllWords: isDemo
+      ? false
+      : localStorage.getItem('sentenceStagesForAllWords') === 'true',
     devTestFinished: devConfig?.testFinished ?? false,
     practiceMode: false,
     wordsInitialized: false,
@@ -334,6 +338,7 @@ const TestWords: React.FC<Props> = ({
               finalStage={!state.sentenceReadEnabled && !state.sentenceWriteEnabled}
               devTestFinished={state.devTestFinished}
               practiceMode={state.practiceMode}
+              sentenceStagesForAllWords={state.sentenceStagesForAllWords}
             />
           </ErrorBoundary>
         );
@@ -380,6 +385,7 @@ const TestWords: React.FC<Props> = ({
             onVocabComplete={onVocabComplete}
             finalStage={!state.sentenceReadEnabled && !state.sentenceWriteEnabled}
             practiceMode={state.practiceMode}
+            sentenceStagesForAllWords={state.sentenceStagesForAllWords}
           />
         );
     }

--- a/web-client/src/services/dashboardService.test.ts
+++ b/web-client/src/services/dashboardService.test.ts
@@ -187,9 +187,11 @@ describe('getDashboardStats', () => {
 
     const stats = await getDashboardStats('user-1');
 
-    // With 2 words and default settings (all stages enabled):
-    // 2 × (8+8+10+10+15 + 5+30+30) = 2 × 116 = 232s → ~4 min
-    expect(stats.estimatedStudyTime).toBe('~4 min');
+    // With 2 words and default settings (all stages enabled, sentenceStagesForAllWords=false):
+    // Vocab: 2 × (8+8+10+10+15) = 102, New words: 2×5 = 10
+    // Sentence word count: max(1, round(2×0.2)) = 1, Sentence: 1×30 + 1×30 = 60
+    // Total: 172s → ~3 min
+    expect(stats.estimatedStudyTime).toBe('~3 min');
   });
 
   it('respects user settings from localStorage for time estimate', async () => {
@@ -204,7 +206,10 @@ describe('getDashboardStats', () => {
 
     const stats = await getDashboardStats('user-1');
 
-    // 20 words × (8+8+10+10+15 + 5+30+30) s/word = 2320s → ~39 min
-    expect(stats.estimatedStudyTime).toBe('~39 min');
+    // 20 words, sentenceStagesForAllWords=false:
+    // Vocab: 20×51=1020, New words: 20×5=100
+    // Sentence word count: max(1, round(20×0.2))=4, Sentence: 4×30+4×30=240
+    // Total: 1360s → ~23 min
+    expect(stats.estimatedStudyTime).toBe('~23 min');
   });
 });

--- a/web-client/src/services/dashboardService.ts
+++ b/web-client/src/services/dashboardService.ts
@@ -44,6 +44,7 @@ export const getDashboardStats = async (userId: string, listId?: string): Promis
         newWordsEnabled: localStorage.getItem('newWords') !== 'false',
         sentenceReadEnabled: localStorage.getItem('sentenceRead') !== 'false',
         sentenceWriteEnabled: localStorage.getItem('sentenceWrite') !== 'false',
+        sentenceStagesForAllWords: localStorage.getItem('sentenceStagesForAllWords') === 'true',
       });
 
       if (totalSeconds >= 3600) {

--- a/web-client/src/utils/estimateTestTime.test.ts
+++ b/web-client/src/utils/estimateTestTime.test.ts
@@ -9,6 +9,7 @@ const defaults: TestTimeEstimateParams = {
   newWordsEnabled: true,
   sentenceReadEnabled: true,
   sentenceWriteEnabled: true,
+  sentenceStagesForAllWords: false,
 };
 
 describe('estimateTestTime', () => {
@@ -16,18 +17,19 @@ describe('estimateTestTime', () => {
     const result = estimateTestTime(defaults);
     // Vocab: 5 * (10+8+8+10+15) = 5 * 51 = 255
     // New words: 5 * 5 = 25
-    // Sentence read: 5 * 30 = 150
-    // Sentence write: 5 * 30 = 150
-    // Total: 580
-    expect(result).toBe(580);
+    // Sentence word count (default off): max(1, round(5*0.2)) = 1
+    // Sentence read: 1 * 30 = 30
+    // Sentence write: 1 * 30 = 30
+    // Total: 340
+    expect(result).toBe(340);
   });
 
   it('calculates time without handwriting', () => {
     const result = estimateTestTime({ ...defaults, useHandwriting: false });
     // Vocab: 5 * (10+8+8+10) = 5 * 36 = 180
-    // Stages: 25 + 150 + 150 = 325
-    // Total: 505
-    expect(result).toBe(505);
+    // New words: 25, Sentence: 30+30
+    // Total: 265
+    expect(result).toBe(265);
   });
 
   it('calculates minimum config', () => {
@@ -39,6 +41,7 @@ describe('estimateTestTime', () => {
       newWordsEnabled: false,
       sentenceReadEnabled: false,
       sentenceWriteEnabled: false,
+      sentenceStagesForAllWords: false,
     });
     // Only MP perm: 1 * 8 = 8
     expect(result).toBe(8);
@@ -53,9 +56,13 @@ describe('estimateTestTime', () => {
       newWordsEnabled: true,
       sentenceReadEnabled: true,
       sentenceWriteEnabled: true,
+      sentenceStagesForAllWords: true,
     });
     // Vocab: 20 * 51 = 1020
-    // Stages: 100 + 600 + 600 = 1300
+    // New words: 100
+    // Sentence word count (all words): 20
+    // Sentence read: 20 * 30 = 600
+    // Sentence write: 20 * 30 = 600
     // Total: 2320
     expect(result).toBe(2320);
   });
@@ -120,7 +127,8 @@ describe('estimateTestTime', () => {
       sentenceReadEnabled: true,
       sentenceWriteEnabled: false,
     });
-    expect(withSentenceRead - vocabOnly).toBe(5 * 30); // 150s
+    // Sentence word count with sentenceStagesForAllWords=false: max(1, round(5*0.2))=1
+    expect(withSentenceRead - vocabOnly).toBe(1 * 30); // 30s
 
     const withSentenceWrite = estimateTestTime({
       ...defaults,
@@ -128,13 +136,70 @@ describe('estimateTestTime', () => {
       sentenceReadEnabled: false,
       sentenceWriteEnabled: true,
     });
-    expect(withSentenceWrite - vocabOnly).toBe(5 * 30); // 150s
+    expect(withSentenceWrite - vocabOnly).toBe(1 * 30); // 30s
   });
 
-  it('scales linearly with numWords', () => {
-    const one = estimateTestTime({ ...defaults, numWords: 1 });
-    const ten = estimateTestTime({ ...defaults, numWords: 10 });
+  it('scales vocab linearly with numWords', () => {
+    const one = estimateTestTime({
+      ...defaults,
+      numWords: 1,
+      sentenceReadEnabled: false,
+      sentenceWriteEnabled: false,
+      newWordsEnabled: false,
+    });
+    const ten = estimateTestTime({
+      ...defaults,
+      numWords: 10,
+      sentenceReadEnabled: false,
+      sentenceWriteEnabled: false,
+      newWordsEnabled: false,
+    });
     expect(ten).toBe(one * 10);
+  });
+
+  it('sentence time scales linearly when sentenceStagesForAllWords is enabled', () => {
+    const five = estimateTestTime({ ...defaults, sentenceStagesForAllWords: true });
+    const ten = estimateTestTime({ ...defaults, numWords: 10, sentenceStagesForAllWords: true });
+    // All components scale linearly when sentenceStagesForAllWords is on
+    expect(ten).toBe(five * 2);
+  });
+
+  it('uses all words for sentence estimate when sentenceStagesForAllWords is enabled', () => {
+    const withAll = estimateTestTime({
+      ...defaults,
+      sentenceStagesForAllWords: true,
+      newWordsEnabled: false,
+    });
+    // Vocab: 5 * 51 = 255
+    // Sentence word count (all): 5
+    // Sentence read: 5 * 30 = 150
+    // Sentence write: 5 * 30 = 150
+    // Total: 555
+    expect(withAll).toBe(555);
+  });
+
+  it('uses reduced word count for sentence estimate when sentenceStagesForAllWords is disabled', () => {
+    const withDefault = estimateTestTime({
+      ...defaults,
+      sentenceStagesForAllWords: false,
+      newWordsEnabled: false,
+    });
+    // Vocab: 5 * 51 = 255
+    // Sentence word count (default): max(1, round(5*0.2)) = 1
+    // Sentence read: 1 * 30 = 30
+    // Sentence write: 1 * 30 = 30
+    // Total: 315
+    expect(withDefault).toBe(315);
+  });
+
+  it('enabling sentenceStagesForAllWords increases estimate over default', () => {
+    const defaultEstimate = estimateTestTime({ ...defaults, numWords: 10 });
+    const allWordsEstimate = estimateTestTime({
+      ...defaults,
+      numWords: 10,
+      sentenceStagesForAllWords: true,
+    });
+    expect(allWordsEstimate).toBeGreaterThan(defaultEstimate);
   });
 });
 

--- a/web-client/src/utils/estimateTestTime.ts
+++ b/web-client/src/utils/estimateTestTime.ts
@@ -6,6 +6,7 @@ export interface TestTimeEstimateParams {
   newWordsEnabled: boolean;
   sentenceReadEnabled: boolean;
   sentenceWriteEnabled: boolean;
+  sentenceStagesForAllWords: boolean;
 }
 
 const PERM_SECONDS: Record<string, number> = {
@@ -29,6 +30,7 @@ export function estimateTestTime(params: TestTimeEstimateParams): number {
     newWordsEnabled,
     sentenceReadEnabled,
     sentenceWriteEnabled,
+    sentenceStagesForAllWords,
   } = params;
 
   let activePerms: string[];
@@ -48,11 +50,20 @@ export function estimateTestTime(params: TestTimeEstimateParams): number {
   if (newWordsEnabled) {
     totalSeconds += numWords * NEW_WORDS_SECONDS_PER_WORD;
   }
+
+  // When sentenceStagesForAllWords is enabled, sentence stages run for every
+  // correctly-answered word, so estimate time for all numWords.
+  // When disabled (default), they only run for new/level-1 words, so use a
+  // reduced estimate (roughly 1 in 5 words are new).
+  const sentenceWordCount = sentenceStagesForAllWords
+    ? numWords
+    : Math.max(1, Math.round(numWords * 0.2));
+
   if (sentenceReadEnabled) {
-    totalSeconds += numWords * SENTENCE_SECONDS_PER_WORD;
+    totalSeconds += sentenceWordCount * SENTENCE_SECONDS_PER_WORD;
   }
   if (sentenceWriteEnabled) {
-    totalSeconds += numWords * SENTENCE_SECONDS_PER_WORD;
+    totalSeconds += sentenceWordCount * SENTENCE_SECONDS_PER_WORD;
   }
 
   return totalSeconds;


### PR DESCRIPTION
## Summary
- Adds a new **"Sentence stages for all words"** checkbox in Settings (under Stages section) that makes sentence stages (Translate Sentences / Make Sentences) run for every correctly-answered word, not just new/level-1 words
- The setting is stored in localStorage (`sentenceStagesForAllWords`), disabled by default, and automatically disabled when both sentence stages are turned off
- Factors the setting into the estimated test time: when off, estimates sentence time for ~20% of words (approximating new-word proportion); when on, estimates for all words

## Test plan
- [x] Unit tests for `estimateTestTime` with `sentenceStagesForAllWords` on/off
- [x] Unit tests for Settings component: checkbox rendering, localStorage persistence, disabled state when sentence stages are off, time estimate updates
- [x] Unit tests for TestWords: `sentenceStagesForAllWords` prop forwarding to Test component
- [x] E2E tests: checkbox visibility, localStorage persistence across reload, disabled state, time estimate update
- [x] All 1148 unit tests pass
- [x] Lint, format, and build checks pass

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)