### PR TITLE
Primary button text must change on sentence stages

### DIFF
--- a/web-client/src/components/Test/SentenceRead/SentenceRead.keyboard.test.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.keyboard.test.tsx
@@ -288,7 +288,7 @@ describe('SentenceRead — keyboard shortcuts ArrowUp/ArrowDown', () => {
     await user.type(input, 'Hello{Enter}');
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /next word/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next stage/i })).toBeInTheDocument();
     });
 
     // ArrowUp from a non-input element triggers onYesClicked

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
@@ -184,7 +184,7 @@ describe('SentenceRead — submitting a translation', () => {
     });
   });
 
-  it('shows similarity score and Next Word/Try Again buttons after submission', async () => {
+  it('shows similarity score and Finish/Try Again buttons after submission on last word', async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
@@ -195,7 +195,7 @@ describe('SentenceRead — submitting a translation', () => {
     await user.type(input, 'Hello{Enter}');
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /next word/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
     });
 
@@ -356,7 +356,7 @@ describe('SentenceRead — text mode (useSound=false)', () => {
 });
 
 describe('SentenceRead — stage completion', () => {
-  it('calls startSentenceWrite after Next Word on the last word (sentenceWriteEnabled=true)', async () => {
+  it('calls startSentenceWrite after Next Stage on the last word (sentenceWriteEnabled=true)', async () => {
     const user = userEvent.setup();
     const startSentenceWrite = vi.fn();
     renderWithProviders(
@@ -371,7 +371,7 @@ describe('SentenceRead — stage completion', () => {
     const input = await screen.findByPlaceholderText(/type your translation/i);
     await user.type(input, 'Hello{Enter}');
 
-    const nextBtn = await screen.findByRole('button', { name: /next word/i });
+    const nextBtn = await screen.findByRole('button', { name: /next stage/i });
     await user.click(nextBtn);
 
     await waitFor(() => {
@@ -690,6 +690,66 @@ describe('SentenceRead — tap affordance', () => {
     expect(popupSpan).toHaveAttribute('data-popup');
     // The span should have role="button" (confirms it communicates interactivity)
     expect(popupSpan).toHaveAttribute('role', 'button');
+  });
+});
+
+describe('SentenceRead — primary button text', () => {
+  it('shows "Next Word" on non-last word', async () => {
+    const user = userEvent.setup();
+    const secondWord: Word = { ...testWord, id: 2, simp: '学生', trad: '學生' };
+    renderWithProviders(
+      <SentenceRead
+        words={[testWord, secondWord]}
+        sentenceWriteEnabled={false}
+        startSentenceWrite={vi.fn()}
+      />,
+      { store: makeStore() },
+    );
+
+    const input = await screen.findByPlaceholderText(/type your translation/i);
+    await user.type(input, 'Hello{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /next word/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Next Stage" on last word when sentenceWriteEnabled=true', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SentenceRead
+        words={[testWord]}
+        sentenceWriteEnabled
+        startSentenceWrite={vi.fn()}
+      />,
+      { store: makeStore() },
+    );
+
+    const input = await screen.findByPlaceholderText(/type your translation/i);
+    await user.type(input, 'Hello{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /next stage/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Finish" on last word when sentenceWriteEnabled=false', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SentenceRead
+        words={[testWord]}
+        sentenceWriteEnabled={false}
+        startSentenceWrite={vi.fn()}
+      />,
+      { store: makeStore() },
+    );
+
+    const input = await screen.findByPlaceholderText(/type your translation/i);
+    await user.type(input, 'Hello{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
+    });
   });
 });
 

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
@@ -717,11 +717,7 @@ describe('SentenceRead — primary button text', () => {
   it('shows "Next Stage" on last word when sentenceWriteEnabled=true', async () => {
     const user = userEvent.setup();
     renderWithProviders(
-      <SentenceRead
-        words={[testWord]}
-        sentenceWriteEnabled
-        startSentenceWrite={vi.fn()}
-      />,
+      <SentenceRead words={[testWord]} sentenceWriteEnabled startSentenceWrite={vi.fn()} />,
       { store: makeStore() },
     );
 
@@ -736,11 +732,7 @@ describe('SentenceRead — primary button text', () => {
   it('shows "Finish" on last word when sentenceWriteEnabled=false', async () => {
     const user = userEvent.setup();
     renderWithProviders(
-      <SentenceRead
-        words={[testWord]}
-        sentenceWriteEnabled={false}
-        startSentenceWrite={vi.fn()}
-      />,
+      <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
       { store: makeStore() },
     );
 

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
@@ -760,8 +760,21 @@ const SentenceRead: React.FC<Props> = ({
         )}
 
         <Stack direction="row" spacing={2} justifyContent="center">
-          <Button clicked={onYesClicked} aria-label="Next word">
-            Next Word
+          <Button
+            clicked={onYesClicked}
+            aria-label={
+              state.wordIndex >= words.length - 1
+                ? sentenceWriteEnabled
+                  ? 'Next stage'
+                  : 'Finish'
+                : 'Next word'
+            }
+          >
+            {state.wordIndex >= words.length - 1
+              ? sentenceWriteEnabled
+                ? 'Next Stage'
+                : 'Finish'
+              : 'Next Word'}
           </Button>
           <Button clicked={onNoClicked} type="secondary" aria-label="Try again">
             Try Again

--- a/web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx
+++ b/web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx
@@ -308,7 +308,7 @@ describe('SentenceWrite — submitting an answer', () => {
     });
   });
 
-  it('shows Next Word/Try Again buttons and similarity score after submission', async () => {
+  it('shows Finish/Try Again buttons and similarity score after submission on last word', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SentenceWrite words={[testWord]} onComplete={vi.fn()} />, {
       store: makeStore(),
@@ -318,7 +318,7 @@ describe('SentenceWrite — submitting an answer', () => {
     await user.type(input, '你好{Enter}');
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /next word/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
     });
 
@@ -392,7 +392,7 @@ describe('SentenceWrite — submitting an answer', () => {
 });
 
 describe('SentenceWrite — stage completion', () => {
-  it('calls onComplete after Next Word click on the last word', async () => {
+  it('calls onComplete after Finish click on the last word', async () => {
     const user = userEvent.setup();
     const onComplete = vi.fn();
     renderWithProviders(<SentenceWrite words={[testWord]} onComplete={onComplete} />, {
@@ -402,7 +402,7 @@ describe('SentenceWrite — stage completion', () => {
     const input = await screen.findByPlaceholderText(/type your answer in chinese/i);
     await user.type(input, '你好{Enter}');
 
-    const nextBtn = await screen.findByRole('button', { name: /next word/i });
+    const nextBtn = await screen.findByRole('button', { name: /finish/i });
     await user.click(nextBtn);
 
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -474,6 +474,37 @@ describe('SentenceWrite — stage completion', () => {
     await waitFor(() => {
       // The first call should use offset 1, not 0, since seenOffset is 0
       expect(mockedGetSegmentedSentence).toHaveBeenCalledWith('你好', expect.any(String), 1);
+    });
+  });
+});
+
+describe('SentenceWrite — primary button text', () => {
+  it('shows "Next Word" on non-last word', async () => {
+    const user = userEvent.setup();
+    const secondWord: Word = { ...testWord, id: 2, simp: '学习', trad: '學習' };
+    renderWithProviders(<SentenceWrite words={[testWord, secondWord]} onComplete={vi.fn()} />, {
+      store: makeStore(),
+    });
+
+    const input = await screen.findByPlaceholderText(/type your answer in chinese/i);
+    await user.type(input, '你好{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /next word/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Finish" on last word', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SentenceWrite words={[testWord]} onComplete={vi.fn()} />, {
+      store: makeStore(),
+    });
+
+    const input = await screen.findByPlaceholderText(/type your answer in chinese/i);
+    await user.type(input, '你好{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
     });
   });
 });
@@ -688,8 +719,8 @@ describe('SentenceWrite — keyboard shortcuts', () => {
     const input = await screen.findByPlaceholderText(/type your answer in chinese/i);
     await user.type(input, '你好{Enter}');
 
-    // Click "Next Word" to advance past the last word
-    const nextBtn = await screen.findByRole('button', { name: /next word/i });
+    // Click "Finish" to advance past the last word
+    const nextBtn = await screen.findByRole('button', { name: /finish/i });
     await user.click(nextBtn);
 
     expect(onComplete).toHaveBeenCalledTimes(1);

--- a/web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx
+++ b/web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx
@@ -516,8 +516,11 @@ const SentenceWrite: React.FC<Props> = ({
           )}
 
           <Stack direction="row" spacing={2} justifyContent="center">
-            <Button clicked={onYesClicked} aria-label="Next word">
-              Next Word
+            <Button
+              clicked={onYesClicked}
+              aria-label={state.wordIndex >= words.length - 1 ? 'Finish' : 'Next word'}
+            >
+              {state.wordIndex >= words.length - 1 ? 'Finish' : 'Next Word'}
             </Button>
             <Button clicked={onNoClicked} type="secondary" aria-label="Try again">
               Try Again


### PR DESCRIPTION
## Summary

Fixes #283 — On the last word of a sentence stage, the primary button now shows contextual text instead of always saying "Next Word":

- **SentenceRead**: Shows "Next Stage" on the last word when the write stage follows, or "Finish" when it's the final stage
- **SentenceWrite**: Shows "Finish" on the last word (since it's always the last sentence stage before summary)
- Non-last words still show "Next Word" as before

## Key implementation details

- Both `SentenceRead.tsx` and `SentenceWrite.tsx` already track `wordIndex` and `words.length`, so the logic is a simple conditional on `wordIndex >= words.length - 1`
- SentenceRead uses the existing `sentenceWriteEnabled` prop to determine whether to show "Next Stage" or "Finish"
- The `aria-label` attributes are also updated dynamically to match the button text for accessibility

## Files modified

- `web-client/src/components/Test/SentenceRead/SentenceRead.tsx` — Dynamic button text and aria-label
- `web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx` — Dynamic button text and aria-label
- `web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx` — Updated existing tests, added 3 new tests for button text variants
- `web-client/src/components/Test/SentenceRead/SentenceRead.keyboard.test.tsx` — Updated test expectation for changed aria-label
- `web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx` — Updated existing tests, added 2 new tests for button text variants

## Test plan

- [x] All 1153 existing tests pass
- [x] New tests verify "Next Word" on non-last words
- [x] New tests verify "Next Stage" on last word when write stage follows
- [x] New tests verify "Finish" on last word when no more stages

---
Closes #283