### PR TITLE
Remove sentence options from practice stages

### DIFF
--- a/web-client/src/components/Test/SentenceRead/SentenceRead.keyboard.test.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.keyboard.test.tsx
@@ -1,13 +1,11 @@
 /**
  * Tests for SentenceRead keyboard shortcuts and error handling paths:
- * - Escape key closes popup
- * - Ctrl+B focuses answerInput
- * - ArrowLeft/ArrowRight navigate sentences
  * - fetchSentence error handling (catch block)
- * - onChangeSentence uses cached sentence without refetch
- * - closePopup logic
  * - Score unavailable when similarity service rejects
  * - Show text chip toggle in audio mode
+ * - ArrowUp advances after submission
+ * - English highlight rendering
+ * - Multi-word navigation
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
@@ -82,19 +80,6 @@ const mockCloudSentence = {
   english: {
     sentence: 'Hello, I am a student.',
     highlight: [[0, 5]] as number[][],
-  },
-};
-
-const mockCloudSentence2 = {
-  chinese: {
-    sentence: '请向他们说声你好。',
-    highlight: [[7, 9]] as number[][],
-    segments: ['请', '向', '他们', '说声', '你好'],
-    targetIndex: 4,
-  },
-  english: {
-    sentence: 'Please say hello to them.',
-    highlight: [] as number[][],
   },
 };
 
@@ -187,45 +172,6 @@ describe('SentenceRead — score unavailable on similarity error', () => {
 });
 
 // ---------------------------------------------------------------------------
-// onChangeSentence uses cached sentence without refetch
-// ---------------------------------------------------------------------------
-describe('SentenceRead — sentence navigation with cached sentences', () => {
-  it('navigates back to a cached sentence without calling getSegmentedSentence again', async () => {
-    const user = userEvent.setup();
-
-    // First call for offset 0, second for offset 1
-    mockedGetSegmentedSentence
-      .mockResolvedValueOnce({ sentence: mockCloudSentence, totalCount: 3 })
-      .mockResolvedValueOnce({ sentence: mockCloudSentence2, totalCount: 3 });
-
-    renderWithProviders(
-      <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
-      { store: makeStore() },
-    );
-
-    // Wait for first sentence to load
-    await waitFor(() => {
-      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    });
-
-    // Click Next to fetch sentence at offset 1
-    const nextBtn = screen.getByRole('button', { name: /next →/i });
-    await user.click(nextBtn);
-
-    await waitFor(() => {
-      expect(mockedGetSegmentedSentence).toHaveBeenCalledTimes(2);
-    });
-
-    // Click Prev to go back to cached sentence at offset 0
-    const prevBtn = await screen.findByRole('button', { name: /← prev/i });
-    await user.click(prevBtn);
-
-    // Should NOT have called getSegmentedSentence again (still 2 calls)
-    expect(mockedGetSegmentedSentence).toHaveBeenCalledTimes(2);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Show text chip toggle in audio mode
 // ---------------------------------------------------------------------------
 describe('SentenceRead — Show text chip in audio mode', () => {
@@ -296,29 +242,6 @@ describe('SentenceRead — keyboard shortcuts ArrowUp/ArrowDown', () => {
 
     await waitFor(() => {
       expect(startSentenceWrite).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('resets to input view on ArrowDown after submission', async () => {
-    const user = userEvent.setup();
-
-    renderWithProviders(
-      <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
-      { store: makeStore() },
-    );
-
-    const input = await screen.findByPlaceholderText(/type your translation/i);
-    await user.type(input, 'Hello{Enter}');
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
-    });
-
-    // ArrowDown from a non-input element triggers onNoClicked
-    fireEvent.keyUp(document.body, { key: 'ArrowDown' });
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/type your translation/i)).toBeInTheDocument();
     });
   });
 });

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.test.tsx
@@ -143,28 +143,6 @@ describe('SentenceRead — sentence display', () => {
       expect(screen.getByPlaceholderText(/type your translation/i)).toBeInTheDocument();
     });
   });
-
-  it('shows Prev sentence button disabled when at sentence 0', async () => {
-    renderWithProviders(
-      <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
-      { store: makeStore() },
-    );
-    await waitFor(() => {
-      const prevBtn = screen.getByRole('button', { name: /← prev/i });
-      expect(prevBtn).toBeDisabled();
-    });
-  });
-
-  it('shows Next sentence button enabled when totalCount > 1', async () => {
-    renderWithProviders(
-      <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
-      { store: makeStore() },
-    );
-    await waitFor(() => {
-      const nextBtn = screen.getByRole('button', { name: /next →/i });
-      expect(nextBtn).not.toBeDisabled();
-    });
-  });
 });
 
 describe('SentenceRead — submitting a translation', () => {
@@ -184,7 +162,7 @@ describe('SentenceRead — submitting a translation', () => {
     });
   });
 
-  it('shows similarity score and Finish/Try Again buttons after submission on last word', async () => {
+  it('shows similarity score and Finish button after submission on last word', async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
@@ -196,35 +174,12 @@ describe('SentenceRead — submitting a translation', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
     });
 
     // Similarity score should appear
     await waitFor(() => {
       expect(screen.getByText('85%')).toBeInTheDocument();
       expect(screen.getByText('Great')).toBeInTheDocument();
-    });
-  });
-
-  it('resets to input view when Try Again is clicked', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <SentenceRead words={[testWord]} sentenceWriteEnabled={false} startSentenceWrite={vi.fn()} />,
-      { store: makeStore() },
-    );
-
-    const input = await screen.findByPlaceholderText(/type your translation/i);
-    await user.type(input, 'Hello{Enter}');
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
-    });
-
-    const tryAgainBtn = screen.getByRole('button', { name: /try again/i });
-    await user.click(tryAgainBtn);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/type your translation/i)).toBeInTheDocument();
     });
   });
 

--- a/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
+++ b/web-client/src/components/Test/SentenceRead/SentenceRead.tsx
@@ -22,7 +22,7 @@ import SimilarityScore from '../../UI/SimilarityScore/SimilarityScore';
 import speakerPic from '../../../assets/images/speaker.png';
 import micPic from '../../../assets/images/microphone.png';
 
-import { beep, fail } from '../constants';
+import { beep } from '../constants';
 
 import * as wordActions from '../../../store/actions/index';
 import { RootState } from '../../../types/store';
@@ -35,15 +35,12 @@ import * as ttsService from '../../../services/ttsService';
 import { getSimilarityScore } from '../../../services/similarityService';
 
 interface SentenceReadState {
-  sentences: ResolvedSentence[];
-  totalCount: number;
+  sentence: ResolvedSentence | null;
   charSet: 'simp' | 'trad';
-  sentenceIndex: number;
   wordIndex: number;
   submitted: boolean;
   entered: string;
   loading: boolean;
-  sentenceLoading: boolean;
   synthLoading: boolean;
   useSound: boolean;
   useEnglishSpeechRecognition: boolean;
@@ -149,15 +146,12 @@ const SentenceRead: React.FC<Props> = ({
     () => localStorage.getItem('tapHintDismissed') !== 'true',
   );
   const [state, setState] = useState<SentenceReadState>({
-    sentences: [],
-    totalCount: 0,
+    sentence: null,
     charSet: (localStorage.getItem('charSet') as 'simp' | 'trad') || 'trad',
-    sentenceIndex: 0,
     wordIndex: 0,
     submitted: false,
     entered: '',
     loading: false,
-    sentenceLoading: false,
     synthLoading: false,
     useSound: true,
     useEnglishSpeechRecognition: false,
@@ -263,31 +257,24 @@ const SentenceRead: React.FC<Props> = ({
   }, [history, sentenceWriteEnabled, startSentenceWrite]);
 
   const fetchSentence = useCallback(
-    async (offset: number, isNewWord: boolean): Promise<void> => {
-      if (isNewWord) {
-        updateState({ loading: true });
-      } else {
-        updateState({ sentenceLoading: true });
-      }
+    async (offset: number): Promise<void> => {
+      updateState({ loading: true });
 
       const currentWord = words[stateRef.current.wordIndex].simp;
 
       try {
-        const { sentence: cloudSentence, totalCount } = await getSegmentedSentence(
+        const { sentence: cloudSentence } = await getSegmentedSentence(
           currentWord,
           stateRef.current.charSet,
           offset,
         );
 
         if (!cloudSentence) {
-          if (isNewWord) {
-            // No sentences found for this word, try next word
-            console.warn(`No sentences found for word: ${currentWord}`);
-            if (stateRef.current.wordIndex >= words.length - 1) {
-              onEndStage();
-            } else {
-              setState((prevState) => ({ ...prevState, wordIndex: prevState.wordIndex + 1 }));
-            }
+          console.warn(`No sentences found for word: ${currentWord}`);
+          if (stateRef.current.wordIndex >= words.length - 1) {
+            onEndStage();
+          } else {
+            setState((prevState) => ({ ...prevState, wordIndex: prevState.wordIndex + 1 }));
           }
           return;
         }
@@ -296,19 +283,13 @@ const SentenceRead: React.FC<Props> = ({
 
         const willSpeak = stateRef.current.useSound;
 
-        setState((prevState) => {
-          const newSentences = isNewWord ? [resolved] : [...prevState.sentences, resolved];
-          return {
-            ...prevState,
-            sentences: newSentences,
-            totalCount,
-            sentenceIndex: offset,
-            loading: false,
-            sentenceLoading: false,
-            showText: false,
-            synthLoading: willSpeak,
-          };
-        });
+        setState((prevState) => ({
+          ...prevState,
+          sentence: resolved,
+          loading: false,
+          showText: false,
+          synthLoading: willSpeak,
+        }));
 
         if (willSpeak) {
           stateRef.current.recognition?.abort();
@@ -330,51 +311,25 @@ const SentenceRead: React.FC<Props> = ({
         }
       } catch (error) {
         console.error('Error fetching sentence:', error);
-        if (isNewWord) {
-          // On error, try next word instead of getting stuck
-          if (stateRef.current.wordIndex >= words.length - 1) {
-            onEndStage();
-          } else {
-            setState((prevState) => ({ ...prevState, wordIndex: prevState.wordIndex + 1 }));
-          }
+        if (stateRef.current.wordIndex >= words.length - 1) {
+          onEndStage();
         } else {
-          updateState({ sentenceLoading: false });
+          setState((prevState) => ({ ...prevState, wordIndex: prevState.wordIndex + 1 }));
         }
       }
     },
     [onEndStage, updateState, words, voice, lang],
   );
 
-  const onChangeSentence = useCallback(
-    (direction: number): void => {
-      const newIndex = stateRef.current.sentenceIndex + direction;
-
-      if (newIndex < 0 || newIndex >= stateRef.current.totalCount) return;
-
-      // If we already have this sentence cached, just navigate
-      if (stateRef.current.sentences[newIndex]) {
-        setState((prevState) => ({
-          ...prevState,
-          sentenceIndex: newIndex,
-          showText: false,
-        }));
-      } else {
-        // Fetch the next sentence from the cloud
-        fetchSentence(newIndex, false);
-      }
-    },
-    [fetchSentence],
-  );
-
   const onYesClicked = (): void => {
     if (stateRef.current.useSound) beep.play();
 
     const currentWord = words[stateRef.current.wordIndex];
-    const seenSentence = stateRef.current.sentences[stateRef.current.sentenceIndex];
+    const currentSentence = stateRef.current.sentence;
     seenOffsets.current[currentWord.simp] = {
-      offset: stateRef.current.sentenceIndex,
-      text: seenSentence?.chinese.sentence ?? '',
-      english: seenSentence?.english.sentence ?? '',
+      offset: 0,
+      text: currentSentence?.chinese.sentence ?? '',
+      english: currentSentence?.english.sentence ?? '',
     };
 
     if (stateRef.current.wordIndex >= words.length - 1) {
@@ -383,9 +338,7 @@ const SentenceRead: React.FC<Props> = ({
       setState((prevState) => ({
         ...prevState,
         wordIndex: prevState.wordIndex + 1,
-        sentenceIndex: 0,
-        sentences: [],
-        totalCount: 0,
+        sentence: null,
         submitted: false,
         entered: '',
         showText: false,
@@ -393,11 +346,6 @@ const SentenceRead: React.FC<Props> = ({
         scoreLoading: false,
       }));
     }
-  };
-
-  const onNoClicked = (): void => {
-    if (stateRef.current.useSound) fail.play();
-    updateState({ entered: '', submitted: false, score: null, scoreLoading: false });
   };
 
   const onInputChanged = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -408,7 +356,7 @@ const SentenceRead: React.FC<Props> = ({
     if (stateRef.current.entered === '') return;
     updateState({ submitted: true, scoreLoading: true, score: null });
 
-    const currentSentence = stateRef.current.sentences[stateRef.current.sentenceIndex];
+    const currentSentence = stateRef.current.sentence;
     if (currentSentence) {
       getSimilarityScore(stateRef.current.entered, currentSentence.english.sentence, 'en')
         .then((result) => {
@@ -443,28 +391,8 @@ const SentenceRead: React.FC<Props> = ({
       if (event.key === 'ArrowUp' && stateRef.current.submitted) {
         onYesClicked();
       }
-
-      if (event.key === 'ArrowDown' && stateRef.current.submitted) {
-        onNoClicked();
-      }
-
-      if (
-        event.key === 'ArrowLeft' &&
-        !stateRef.current.submitted &&
-        stateRef.current.sentenceIndex > 0
-      ) {
-        onChangeSentence(-1);
-      }
-
-      if (
-        event.key === 'ArrowRight' &&
-        !stateRef.current.submitted &&
-        stateRef.current.sentenceIndex < stateRef.current.totalCount - 1
-      ) {
-        onChangeSentence(1);
-      }
     },
-    [onChangeSentence, onNoClicked, onYesClicked, updateState],
+    [onYesClicked, updateState],
   );
 
   const onToggleText = (): void => {
@@ -513,7 +441,7 @@ const SentenceRead: React.FC<Props> = ({
   useEffect(() => {
     if (!hasInitialized.current) {
       hasInitialized.current = true;
-      fetchSentence(0, true);
+      fetchSentence(0);
       initialiseSettings();
     }
     document.addEventListener('keyup', onKeyUp);
@@ -527,27 +455,16 @@ const SentenceRead: React.FC<Props> = ({
   const prevWordIndex = useRef(state.wordIndex);
   useEffect(() => {
     if (prevWordIndex.current !== state.wordIndex) {
-      fetchSentence(0, true);
+      fetchSentence(0);
     }
     prevWordIndex.current = state.wordIndex;
   }, [fetchSentence, state.wordIndex]);
 
-  // Speak sentence when navigating to a cached sentence
-  const prevSentenceIndex = useRef(state.sentenceIndex);
-  useEffect(() => {
-    if (prevSentenceIndex.current !== state.sentenceIndex) {
-      if (state.useSound && state.sentences[state.sentenceIndex]) {
-        onSpeakPinyin(state.sentences[state.sentenceIndex].chinese.sentence);
-      }
-    }
-    prevSentenceIndex.current = state.sentenceIndex;
-  }, [onSpeakPinyin, state.sentenceIndex, state.sentences, state.useSound]);
-
   // ── Sentence display content ──────────────────────────────────────────────
   let sentenceCardContent: React.ReactNode = <Spinner />;
 
-  if (state.sentences[state.sentenceIndex] && !state.loading) {
-    const currentSentence = state.sentences[state.sentenceIndex];
+  if (state.sentence && !state.loading) {
+    const currentSentence = state.sentence;
     const targetIndex = currentSentence.chinese.targetIndex;
     const currentTargetWord = words[state.wordIndex]?.[state.charSet] || '';
 
@@ -705,7 +622,7 @@ const SentenceRead: React.FC<Props> = ({
   let mainContent: React.ReactNode;
 
   if (state.submitted) {
-    const currentSentence = state.sentences[state.sentenceIndex];
+    const currentSentence = state.sentence!;
     let translation: React.ReactNode = currentSentence.english.sentence;
 
     if (currentSentence.english.highlight.length > 0) {
@@ -759,27 +676,22 @@ const SentenceRead: React.FC<Props> = ({
           </Typography>
         )}
 
-        <Stack direction="row" spacing={2} justifyContent="center">
-          <Button
-            clicked={onYesClicked}
-            aria-label={
-              state.wordIndex >= words.length - 1
-                ? sentenceWriteEnabled
-                  ? 'Next stage'
-                  : 'Finish'
-                : 'Next word'
-            }
-          >
-            {state.wordIndex >= words.length - 1
+        <Button
+          clicked={onYesClicked}
+          aria-label={
+            state.wordIndex >= words.length - 1
               ? sentenceWriteEnabled
-                ? 'Next Stage'
+                ? 'Next stage'
                 : 'Finish'
-              : 'Next Word'}
-          </Button>
-          <Button clicked={onNoClicked} type="secondary" aria-label="Try again">
-            Try Again
-          </Button>
-        </Stack>
+              : 'Next word'
+          }
+        >
+          {state.wordIndex >= words.length - 1
+            ? sentenceWriteEnabled
+              ? 'Next Stage'
+              : 'Finish'
+            : 'Next Word'}
+        </Button>
       </Stack>
     );
   } else {
@@ -828,30 +740,6 @@ const SentenceRead: React.FC<Props> = ({
         </Box>
 
         {micButton}
-
-        {/* Navigation row */}
-        <Stack
-          direction="row"
-          spacing={1}
-          justifyContent="center"
-          alignItems="center"
-          flexWrap="wrap"
-        >
-          <Button
-            clicked={() => onChangeSentence(-1)}
-            disabled={state.sentenceIndex < 1}
-            type="ghost"
-          >
-            ← Prev
-          </Button>
-          <Button
-            clicked={() => onChangeSentence(1)}
-            disabled={state.sentenceLoading || state.sentenceIndex >= state.totalCount - 1}
-            type="ghost"
-          >
-            {state.sentenceLoading ? 'Loading…' : 'Next →'}
-          </Button>
-        </Stack>
       </Stack>
     );
   }
@@ -917,9 +805,7 @@ const SentenceRead: React.FC<Props> = ({
             display: 'block',
             mt: 1,
             visibility:
-              (!state.useSound || state.showText) &&
-              !!state.sentences[state.sentenceIndex] &&
-              !state.loading
+              (!state.useSound || state.showText) && !!state.sentence && !state.loading
                 ? 'visible'
                 : 'hidden',
           }}

--- a/web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx
+++ b/web-client/src/components/Test/SentenceWrite/SentenceWrite.test.tsx
@@ -308,7 +308,7 @@ describe('SentenceWrite — submitting an answer', () => {
     });
   });
 
-  it('shows Finish/Try Again buttons and similarity score after submission on last word', async () => {
+  it('shows Finish button and similarity score after submission on last word', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SentenceWrite words={[testWord]} onComplete={vi.fn()} />, {
       store: makeStore(),
@@ -319,30 +319,12 @@ describe('SentenceWrite — submitting an answer', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
     });
 
     // Similarity score should appear
     await waitFor(() => {
       expect(screen.getByText('72%')).toBeInTheDocument();
       expect(screen.getByText('Good')).toBeInTheDocument();
-    });
-  });
-
-  it('resets to input view when Try Again clicked', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<SentenceWrite words={[testWord]} onComplete={vi.fn()} />, {
-      store: makeStore(),
-    });
-
-    const input = await screen.findByPlaceholderText(/type your answer in chinese/i);
-    await user.type(input, '你好{Enter}');
-
-    const tryAgainBtn = await screen.findByRole('button', { name: /try again/i });
-    await user.click(tryAgainBtn);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/type your answer in chinese/i)).toBeInTheDocument();
     });
   });
 
@@ -752,28 +734,6 @@ describe('SentenceWrite — keyboard shortcuts', () => {
         expect.any(String),
         expect.any(Number),
       );
-    });
-  });
-
-  it('resets to input view on ArrowDown when submitted', async () => {
-    const user = userEvent.setup();
-
-    renderWithProviders(<SentenceWrite words={[testWord]} onComplete={vi.fn()} />, {
-      store: makeStore(),
-    });
-
-    const input = await screen.findByPlaceholderText(/type your answer in chinese/i);
-    await user.type(input, '你好{Enter}');
-
-    await waitFor(() => {
-      expect(screen.getByText(/your answer/i)).toBeInTheDocument();
-    });
-
-    // Press ArrowDown to trigger onNoClicked (Try Again)
-    await user.keyboard('{ArrowDown}');
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/type your answer in chinese/i)).toBeInTheDocument();
     });
   });
 

--- a/web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx
+++ b/web-client/src/components/Test/SentenceWrite/SentenceWrite.tsx
@@ -11,7 +11,7 @@ import SimilarityScore from '../../UI/SimilarityScore/SimilarityScore';
 
 import micPic from '../../../assets/images/microphone.png';
 
-import { beep, fail } from '../constants';
+import { beep } from '../constants';
 
 import { RootState } from '../../../types/store';
 import { Word } from '../../../types/models';
@@ -307,21 +307,6 @@ const SentenceWrite: React.FC<Props> = ({
     }
   }, [fetchSentence, onComplete, seenOffsets, words]);
 
-  const onNoClicked = useCallback((): void => {
-    if (stateRef.current.useSound) fail.play();
-    setState((prev) => ({
-      ...prev,
-      entered: '',
-      submitted: false,
-      message: 'Try again',
-      selectedWordIndices: new Set<number>(),
-      translationResults: [],
-      showTranslation: false,
-      score: null,
-      scoreLoading: false,
-    }));
-  }, []);
-
   const onToggleWord = useCallback((index: number): void => {
     setState((prev) => {
       const next = new Set(prev.selectedWordIndices);
@@ -380,12 +365,8 @@ const SentenceWrite: React.FC<Props> = ({
       if (event.key === 'ArrowUp' && stateRef.current.submitted) {
         onYesClicked();
       }
-
-      if (event.key === 'ArrowDown' && stateRef.current.submitted) {
-        onNoClicked();
-      }
     },
-    [onHomeClicked, onListenPinyin, onNoClicked, onYesClicked, words.length],
+    [onHomeClicked, onListenPinyin, onYesClicked, words.length],
   );
 
   useEffect(() => {
@@ -515,17 +496,12 @@ const SentenceWrite: React.FC<Props> = ({
             </Typography>
           )}
 
-          <Stack direction="row" spacing={2} justifyContent="center">
-            <Button
-              clicked={onYesClicked}
-              aria-label={state.wordIndex >= words.length - 1 ? 'Finish' : 'Next word'}
-            >
-              {state.wordIndex >= words.length - 1 ? 'Finish' : 'Next Word'}
-            </Button>
-            <Button clicked={onNoClicked} type="secondary" aria-label="Try again">
-              Try Again
-            </Button>
-          </Stack>
+          <Button
+            clicked={onYesClicked}
+            aria-label={state.wordIndex >= words.length - 1 ? 'Finish' : 'Next word'}
+          >
+            {state.wordIndex >= words.length - 1 ? 'Finish' : 'Next Word'}
+          </Button>
         </Stack>
       </Box>
     );


### PR DESCRIPTION
## Summary
- Remove Prev/Next sentence navigation buttons from SentenceRead stage — users now see one sentence per word
- Remove "Try Again" button from both SentenceRead and SentenceWrite stages — users move on after submission
- Clean up related state (`sentenceIndex`, `sentences` array, `totalCount`, `sentenceLoading`), functions (`onChangeSentence`, `onNoClicked`), and keyboard shortcuts (ArrowDown, ArrowLeft, ArrowRight)
- Update tests to remove coverage for deleted features

Closes #289

## Test plan
- [ ] Verify SentenceRead shows a single sentence with no Prev/Next buttons
- [ ] Verify SentenceRead submission shows score + "Next Word" only (no "Try Again")
- [ ] Verify SentenceWrite submission shows score + "Next Word" only (no "Try Again")
- [ ] Verify ArrowUp keyboard shortcut still advances after submission
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)