### PR TITLE
Disable E2E tests in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,109 +97,110 @@ jobs:
         run: npm run build
         working-directory: functions
 
-  e2e-tests:
-    name: E2E Tests
-    needs: [unit-tests, build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-client/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: web-client
-
-      - name: Install root dependencies
-        run: npm ci
-
-      - name: Install Functions dependencies
-        run: npm ci
-        working-directory: functions
-
-      - name: Build Functions
-        run: npm run build
-        working-directory: functions
-
-      - name: Build dictionary
-        run: npm run build:dict
-        working-directory: web-client
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-        working-directory: web-client
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
-      - name: Start emulators
-        run: |
-          nohup firebase emulators:start --project hanlearn-dd14f > /tmp/emulator.log 2>&1 &
-          echo $! > /tmp/emulator.pid
-
-      - name: Wait for emulators
-        run: |
-          PID=$(cat /tmp/emulator.pid)
-          for i in $(seq 1 90); do
-            if ! kill -0 $PID 2>/dev/null; then
-              echo "--- Emulator process (PID $PID) died! Log: ---"
-              cat /tmp/emulator.log
-              exit 1
-            fi
-            FIRESTORE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://localhost:8082/ 2>/dev/null) || true
-            AUTH=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://localhost:9099/ 2>/dev/null) || true
-            FUNCTIONS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://localhost:5001/ 2>/dev/null) || true
-            echo "Attempt $i: Firestore=$FIRESTORE Auth=$AUTH Functions=$FUNCTIONS"
-            if [ "$FIRESTORE" != "000" ] && [ "$AUTH" != "000" ] && [ "$FUNCTIONS" != "000" ]; then
-              echo "All emulators ready (PID $PID)"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "--- Emulator log ---"
-          cat /tmp/emulator.log
-          echo "Emulators failed to start" && exit 1
-
-      - name: Verify emulators still running
-        run: |
-          PID=$(cat /tmp/emulator.pid)
-          if ! kill -0 $PID 2>/dev/null; then
-            echo "Emulators died after startup!"
-            cat /tmp/emulator.log
-            exit 1
-          fi
-          echo "Emulators still running (PID $PID)"
-
-      - name: Run E2E tests
-        run: npm run test:e2e
-        working-directory: web-client
-        env:
-          VITE_FIREBASE_API_KEY: fake-api-key
-          VITE_FIREBASE_AUTH_DOMAIN: localhost
-          VITE_FIREBASE_PROJECT_ID: hanlearn-dd14f
-          VITE_FIREBASE_STORAGE_BUCKET: fake-bucket
-          VITE_FIREBASE_MESSAGING_SENDER_ID: '000000000000'
-          VITE_FIREBASE_APP_ID: '1:000000000000:web:fake'
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: web-client/playwright-report/
-
-      - name: Upload emulator logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: emulator-log
-          path: /tmp/emulator.log
+  # E2E tests temporarily disabled — re-enable when emulator infra is stable
+  # e2e-tests:
+  #   name: E2E Tests
+  #   needs: [unit-tests, build]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '20'
+  #         cache: 'npm'
+  #         cache-dependency-path: web-client/package-lock.json
+  #
+  #     - name: Install dependencies
+  #       run: npm ci
+  #       working-directory: web-client
+  #
+  #     - name: Install root dependencies
+  #       run: npm ci
+  #
+  #     - name: Install Functions dependencies
+  #       run: npm ci
+  #       working-directory: functions
+  #
+  #     - name: Build Functions
+  #       run: npm run build
+  #       working-directory: functions
+  #
+  #     - name: Build dictionary
+  #       run: npm run build:dict
+  #       working-directory: web-client
+  #
+  #     - name: Install Playwright browsers
+  #       run: npx playwright install --with-deps chromium
+  #       working-directory: web-client
+  #
+  #     - uses: actions/setup-java@v4
+  #       with:
+  #         distribution: 'temurin'
+  #         java-version: '21'
+  #
+  #     - name: Install Firebase CLI
+  #       run: npm install -g firebase-tools
+  #
+  #     - name: Start emulators
+  #       run: |
+  #         nohup firebase emulators:start --project hanlearn-dd14f > /tmp/emulator.log 2>&1 &
+  #         echo $! > /tmp/emulator.pid
+  #
+  #     - name: Wait for emulators
+  #       run: |
+  #         PID=$(cat /tmp/emulator.pid)
+  #         for i in $(seq 1 90); do
+  #           if ! kill -0 $PID 2>/dev/null; then
+  #             echo "--- Emulator process (PID $PID) died! Log: ---"
+  #             cat /tmp/emulator.log
+  #             exit 1
+  #           fi
+  #           FIRESTORE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://localhost:8082/ 2>/dev/null) || true
+  #           AUTH=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://localhost:9099/ 2>/dev/null) || true
+  #           FUNCTIONS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://localhost:5001/ 2>/dev/null) || true
+  #           echo "Attempt $i: Firestore=$FIRESTORE Auth=$AUTH Functions=$FUNCTIONS"
+  #           if [ "$FIRESTORE" != "000" ] && [ "$AUTH" != "000" ] && [ "$FUNCTIONS" != "000" ]; then
+  #             echo "All emulators ready (PID $PID)"
+  #             exit 0
+  #           fi
+  #           sleep 2
+  #         done
+  #         echo "--- Emulator log ---"
+  #         cat /tmp/emulator.log
+  #         echo "Emulators failed to start" && exit 1
+  #
+  #     - name: Verify emulators still running
+  #       run: |
+  #         PID=$(cat /tmp/emulator.pid)
+  #         if ! kill -0 $PID 2>/dev/null; then
+  #           echo "Emulators died after startup!"
+  #           cat /tmp/emulator.log
+  #           exit 1
+  #         fi
+  #         echo "Emulators still running (PID $PID)"
+  #
+  #     - name: Run E2E tests
+  #       run: npm run test:e2e
+  #       working-directory: web-client
+  #       env:
+  #         VITE_FIREBASE_API_KEY: fake-api-key
+  #         VITE_FIREBASE_AUTH_DOMAIN: localhost
+  #         VITE_FIREBASE_PROJECT_ID: hanlearn-dd14f
+  #         VITE_FIREBASE_STORAGE_BUCKET: fake-bucket
+  #         VITE_FIREBASE_MESSAGING_SENDER_ID: '000000000000'
+  #         VITE_FIREBASE_APP_ID: '1:000000000000:web:fake'
+  #
+  #     - name: Upload Playwright report
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: playwright-report
+  #         path: web-client/playwright-report/
+  #
+  #     - name: Upload emulator logs
+  #       if: failure()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: emulator-log
+  #         path: /tmp/emulator.log


### PR DESCRIPTION
## Summary
- Comments out the `e2e-tests` job in the CI workflow so it no longer runs on PRs
- E2E test code in `web-client/e2e/` is untouched — uncomment the job to reinstate

## Test plan
- [x] Verify CI workflow YAML is valid (only the e2e-tests job is commented out, other jobs unchanged)
- [ ] Confirm CI passes on this PR without running E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)