### PR TITLE
Expand Sentry coverage to auth and test-completion flows

### DIFF
--- a/web-client/src/store/actions/auth.test.ts
+++ b/web-client/src/store/actions/auth.test.ts
@@ -2,12 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestStore } from '../../test/utils';
 import * as authActions from './auth';
 import * as firebaseAuth from '../../firebase/auth';
+import * as Sentry from '@sentry/react';
 import { FirebaseError } from 'firebase/app';
 
 vi.mock('../../firebase/config', () => ({ auth: {}, db: {}, functions: {}, ai: {} }));
 vi.mock('../../firebase/auth');
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+  setUser: vi.fn(),
+}));
 
 const mockedAuth = vi.mocked(firebaseAuth);
+const mockedSentry = vi.mocked(Sentry);
 
 function makeUser(uid: string) {
   return { uid } as firebaseAuth.User;
@@ -445,6 +451,97 @@ describe('auth action thunks', () => {
       store.dispatch(authActions.authCheckState() as any);
 
       expect(mockedAuth.subscribeToAuthChanges).toHaveBeenCalled();
+    });
+  });
+
+  describe('Sentry reporting', () => {
+    it('does NOT report known Firebase error codes (user-input errors)', async () => {
+      const knownCodes = [
+        'auth/wrong-password',
+        'auth/invalid-credential',
+        'auth/user-not-found',
+        'auth/email-already-in-use',
+        'auth/popup-closed-by-user',
+        'auth/cancelled-popup-request',
+        'auth/weak-password',
+        'auth/too-many-requests',
+      ];
+
+      for (const code of knownCodes) {
+        mockedSentry.captureException.mockClear();
+        mockedAuth.loginUser.mockRejectedValue(new FirebaseError(code, 'msg'));
+        const store = createTestStore(defaultStoreState);
+
+        await store.dispatch(authActions.auth('e@e.com', 'pw') as any);
+
+        expect(
+          mockedSentry.captureException,
+          `expected no Sentry report for ${code}`,
+        ).not.toHaveBeenCalled();
+      }
+    });
+
+    it('reports unknown Firebase error codes to Sentry', async () => {
+      const unknownError = new FirebaseError('auth/something-new', 'msg');
+      mockedAuth.loginUser.mockRejectedValue(unknownError);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.auth('e@e.com', 'pw') as any);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(unknownError);
+    });
+
+    it('reports non-Firebase errors to Sentry from login', async () => {
+      const networkErr = new Error('Network failed');
+      mockedAuth.loginUser.mockRejectedValue(networkErr);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.auth('e@e.com', 'pw') as any);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(networkErr);
+    });
+
+    it('reports non-Firebase errors to Sentry from register', async () => {
+      const err = new Error('boom');
+      mockedAuth.registerUser.mockRejectedValue(err);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.register('e@e.com', 'pw') as any);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(err);
+    });
+
+    it('reports non-Firebase errors to Sentry from googleSignIn', async () => {
+      const err = new Error('boom');
+      mockedAuth.signInWithGoogle.mockRejectedValue(err);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.googleSignIn() as any);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(err);
+    });
+
+    it('reports non-Firebase errors to Sentry from sendPasswordReset', async () => {
+      const err = new Error('boom');
+      mockedAuth.resetPassword.mockRejectedValue(err);
+      const store = createTestStore(defaultStoreState);
+
+      await store.dispatch(authActions.sendPasswordReset('e@e.com') as any);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(err);
+    });
+
+    it('reports logout failures to Sentry (should never happen in practice)', async () => {
+      const err = new Error('Firebase offline');
+      mockedAuth.logoutUser.mockRejectedValue(err);
+      const store = createTestStore({
+        ...defaultStoreState,
+        auth: { ...defaultStoreState.auth, userId: 'u1', initialized: true },
+      });
+
+      await store.dispatch(authActions.logout() as any);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(err);
     });
   });
 });

--- a/web-client/src/store/actions/auth.ts
+++ b/web-client/src/store/actions/auth.ts
@@ -93,6 +93,7 @@ export const sendPasswordReset = (email: string): AppThunk => {
       } else {
         dispatch(authFail('Failed to send reset email'));
       }
+      reportUnexpectedAuthError(error);
     }
   };
 };
@@ -106,12 +107,43 @@ export const logout = (): AppThunk => {
       } as AuthLogoutAction);
     } catch (error) {
       console.error('Logout error:', error);
+      Sentry.captureException(error);
       // Still dispatch logout even if Firebase call fails
       dispatch({
         type: actionTypes.AUTH_LOGOUT,
       } as AuthLogoutAction);
     }
   };
+};
+
+const KNOWN_AUTH_ERROR_CODES = new Set<string>([
+  'auth/email-already-in-use',
+  'auth/invalid-email',
+  'auth/operation-not-allowed',
+  'auth/weak-password',
+  'auth/user-disabled',
+  'auth/user-not-found',
+  'auth/wrong-password',
+  'auth/invalid-credential',
+  'auth/too-many-requests',
+  'auth/popup-blocked',
+  'auth/account-exists-with-different-credential',
+  'auth/popup-closed-by-user',
+  'auth/cancelled-popup-request',
+]);
+
+// Only unanticipated failures (unknown Firebase codes, or non-Firebase errors
+// like network / SDK bugs) are sent to Sentry. Expected user-input errors
+// (wrong-password, email-in-use, popup-closed, etc.) are user flow noise.
+const reportUnexpectedAuthError = (error: unknown): void => {
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as FirebaseError).code;
+    if (!KNOWN_AUTH_ERROR_CODES.has(code)) {
+      Sentry.captureException(error);
+    }
+    return;
+  }
+  Sentry.captureException(error);
 };
 
 /**
@@ -161,6 +193,7 @@ export const auth = (email: string, password: string): AppThunk => {
       } else {
         dispatch(authFail('Login failed'));
       }
+      reportUnexpectedAuthError(error);
     }
   };
 };
@@ -178,6 +211,7 @@ export const register = (email: string, password: string): AppThunk => {
       } else {
         dispatch(authFail('Registration failed'));
       }
+      reportUnexpectedAuthError(error);
     }
   };
 };
@@ -199,6 +233,7 @@ export const googleSignIn = (): AppThunk => {
       } else {
         dispatch(authFail('Google sign-in failed'));
       }
+      reportUnexpectedAuthError(error);
     }
   };
 };

--- a/web-client/src/store/actions/word.test.ts
+++ b/web-client/src/store/actions/word.test.ts
@@ -3,6 +3,7 @@ import { createTestStore, authenticatedState } from '../../test/utils';
 import * as wordActions from './word';
 import * as wordService from '../../services/wordService';
 import * as streakService from '../../services/streakService';
+import * as Sentry from '@sentry/react';
 import { Word } from '../../types/models';
 
 vi.mock('../../firebase/config', () => ({
@@ -21,9 +22,14 @@ vi.mock('../../services/performanceService', () => ({
 vi.mock('../../services/analyticsService', () => ({
   trackFeatureUsage: vi.fn(),
 }));
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+  setUser: vi.fn(),
+}));
 
 const mockedWordService = vi.mocked(wordService);
 const mockedStreakService = vi.mocked(streakService);
+const mockedSentry = vi.mocked(Sentry);
 
 const sampleWord: Word = {
   id: 1,
@@ -280,10 +286,11 @@ describe('word action thunks', () => {
       expect(mockedStreakService.recordTestCompletion).toHaveBeenCalledWith('test-user-123');
     });
 
-    it('still succeeds if streak recording fails', async () => {
+    it('still succeeds if streak recording fails, and reports to Sentry', async () => {
+      const streakError = new Error('streak error');
       mockedWordService.finishTest.mockResolvedValue({ 你好: '2026/03/05' });
       mockedWordService.getUserWords.mockResolvedValue(sampleWords);
-      mockedStreakService.recordTestCompletion.mockRejectedValue(new Error('streak error'));
+      mockedStreakService.recordTestCompletion.mockRejectedValue(streakError);
       const store = createTestStore(authenticatedState());
 
       // Should not throw
@@ -291,11 +298,13 @@ describe('word action thunks', () => {
 
       expect(mockedWordService.finishTest).toHaveBeenCalled();
       expect(mockedStreakService.recordTestCompletion).toHaveBeenCalled();
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(streakError);
     });
 
-    it('still records streak if word refresh fails', async () => {
+    it('still records streak if word refresh fails, and reports to Sentry', async () => {
+      const fetchError = new Error('fetch failed');
       mockedWordService.finishTest.mockResolvedValue({ 你好: '2026/03/05' });
-      mockedWordService.getUserWords.mockRejectedValue(new Error('fetch failed'));
+      mockedWordService.getUserWords.mockRejectedValue(fetchError);
       mockedStreakService.recordTestCompletion.mockResolvedValue(undefined);
       const store = createTestStore(authenticatedState());
 
@@ -304,6 +313,7 @@ describe('word action thunks', () => {
       expect(mockedWordService.finishTest).toHaveBeenCalled();
       expect(mockedWordService.getUserWords).toHaveBeenCalled();
       expect(mockedStreakService.recordTestCompletion).toHaveBeenCalled();
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(fetchError);
     });
 
     it('does nothing when no userId', async () => {

--- a/web-client/src/store/actions/word.ts
+++ b/web-client/src/store/actions/word.ts
@@ -354,12 +354,14 @@ export const finishTest = (scores: { word_id: number; score: number }[]): AppThu
           dispatch(setListStats(stats));
         } catch (fetchError) {
           console.error('Failed to refresh words after test:', fetchError);
+          Sentry.captureException(fetchError);
         }
 
         try {
           await recordTestCompletion(auth.userId!);
         } catch (streakError) {
           console.error('Failed to record streak:', streakError);
+          Sentry.captureException(streakError);
         }
       });
 


### PR DESCRIPTION
## Summary
- Auth failures (login, register, google sign-in, password reset, logout) now reach Sentry — previously they were silently swallowed, so a broken auth flow would give zero signal.
- `finishTest` now captures the two inner errors that were `console.error`'d only: the post-test word refresh and streak recording failures.
- Noise-control: a helper filters out expected user-input failures (wrong-password, popup-closed-by-user, email-already-in-use, etc.) so Sentry only sees unanticipated errors.

## Coverage before vs after
Before: ErrorBoundary + 10 write-path thunks in `word.ts`.
After: + all 5 auth thunks (unexpected errors only) + 2 previously-swallowed inner errors in `finishTest`.

## Test plan
- [x] `auth.test.ts` — 7 new tests: known Firebase codes are NOT reported; unknown codes + non-Firebase errors ARE reported from every auth thunk (login, register, googleSignIn, sendPasswordReset, logout).
- [x] `word.test.ts` — the two existing `finishTest` error-path tests now also assert `Sentry.captureException` was called with the originating error.
- [x] Full test suite: 1160/1160 pass.
- [ ] Verify in production after merge that expected user-input errors (e.g. wrong password on login) do not show up in Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)