### PR TITLE
fix: prevent WordCard crash when lists prop is undefined

### DIFF
--- a/web-client/src/components/AddWords/WordCard.tsx
+++ b/web-client/src/components/AddWords/WordCard.tsx
@@ -23,7 +23,7 @@ interface WordCardProps {
 const WordCard: React.FC<WordCardProps> = ({
   word,
   charSet,
-  lists,
+  lists = [],
   onDeleteWord,
   onPostMeaningUpdate,
   onMoveWord,

--- a/web-client/src/containers/AddWords/AddWords.keyboard.test.tsx
+++ b/web-client/src/containers/AddWords/AddWords.keyboard.test.tsx
@@ -172,7 +172,12 @@ describe('AddWords — Escape key dismisses modals', () => {
     mockedWordService.getUserWords.mockResolvedValue([sampleWord]);
     const store = createTestStore({
       ...authenticatedState(),
-      addWords: { words: [sampleWord], error: false, loading: false },
+      addWords: {
+        ...authenticatedState().addWords,
+        words: [sampleWord],
+        error: false,
+        loading: false,
+      },
     });
     renderWithProviders(<AddWords />, { store });
 
@@ -266,7 +271,12 @@ describe('AddWords — "Test" button navigates to test page', () => {
   it('renders the "Test" button when words are in the list', async () => {
     const store = createTestStore({
       ...authenticatedState(),
-      addWords: { words: [sampleWord], error: false, loading: false },
+      addWords: {
+        ...authenticatedState().addWords,
+        words: [sampleWord],
+        error: false,
+        loading: false,
+      },
     });
 
     renderWithProviders(<AddWords />, { store });
@@ -278,7 +288,12 @@ describe('AddWords — "Test" button navigates to test page', () => {
   it('clicking the "Test" button does not throw and changes location', async () => {
     const store = createTestStore({
       ...authenticatedState(),
-      addWords: { words: [sampleWord], error: false, loading: false },
+      addWords: {
+        ...authenticatedState().addWords,
+        words: [sampleWord],
+        error: false,
+        loading: false,
+      },
     });
 
     renderWithProviders(<AddWords />, { store });


### PR DESCRIPTION
## Summary
- CI Unit Tests on the `develop` → `main` release PR (#295) were failing with `TypeError: Cannot read properties of undefined (reading 'filter')` at `WordCard.tsx:54`.
- The move-to-list change wires `lists` from the `AddWords` container into `WordCard`, but three test stores in `AddWords.keyboard.test.tsx` override the `addWords` slice without including `lists`, so `WordCard` crashed and that error cascaded through the test file.
- Two fixes: (1) default `lists` to `[]` in `WordCard` so a missing prop can't crash render; (2) backfill the three keyboard test stores by spreading `authenticatedState().addWords`.

## Test plan
- [x] `vitest run` on the affected files — 41/41 pass
- [x] Full suite `vitest run` — 1158/1158 pass
- [ ] CI Unit Tests pass on this PR
- [ ] Re-run the release PR (`develop` → `main`) once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)